### PR TITLE
tests: add PHPUnit & Travis CI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: false
+language: php
+php:
+  - 7.0
+  - 5.6
+  - 5.5
+  - 5.4
+install:
+  - composer self-update
+  - composer install
+script:
+  - make test

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 
+Copyright (c) 2015-2016 Kafene and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+BIN = vendor/bin
+
+test:
+	@$(BIN)/phpunit tests

--- a/composer.json
+++ b/composer.json
@@ -4,5 +4,9 @@
     "keywords": ["parse", "bookmark", "netscape"],
     "homepage": "https://github.com/kafene/BookmarkParser",
     "license": "MIT",
-    "autoload": {"files": ["parse_netscape_bookmarks.php"]}
+    "autoload": {"files": ["parse_netscape_bookmarks.php"]},
+    "require": {},
+    "require-dev": {
+        "phpunit/phpunit": "4.6.*"
+    }
 }

--- a/tests/ParseNetscapeBookmarksTest.php
+++ b/tests/ParseNetscapeBookmarksTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Ensure basic Netscape bookmarks are properly parsed
+ *
+ * @see https://msdn.microsoft.com/en-us/library/aa753582%28v=vs.85%29.aspx
+ * @see http://www.w3schools.com/tags/tag_dl.asp
+ */
+class ParseNetscapeBookmarksTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Parse a basic Netscape file
+     */
+    public function test_parse_basic()
+    {
+        $bkm = parse_netscape_bookmarks(
+            file_get_contents('tests/input/netscape_basic.htm')
+        );
+        $this->assertEquals(2, sizeof($bkm));
+
+        $this->assertEquals('Secret stuff', $bkm[0]['title']);
+        $this->assertEquals(0, $bkm[0]['pub']);
+        $this->assertEquals('private secret', $bkm[0]['tags']);
+        $this->assertEquals(
+            'Super-secret stuff you\'re not supposed to know about',
+            $bkm[0]['note']
+        );
+
+        $this->assertEquals('Public stuff', $bkm[1]['title']);
+        $this->assertEquals(1, $bkm[1]['pub']);
+        $this->assertEquals('public hello world', $bkm[1]['tags']);
+        $this->assertEquals('', $bkm[1]['note']);
+    }
+}

--- a/tests/input/netscape_basic.htm
+++ b/tests/input/netscape_basic.htm
@@ -1,0 +1,11 @@
+<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<!-- This is an automatically generated file.
+It will be read and overwritten.
+Do Not Edit! -->
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+<DT><A HREF="https://private.tld" ADD_DATE="" PRIVATE="1" TAGS="private secret">Secret stuff</A>
+<DD>Super-secret stuff you're not supposed to know about
+<DT><A HREF="http://public.tld" ADD_DATE="" PRIVATE="0" TAGS="public hello world">Public stuff</A>
+</DL><p>


### PR DESCRIPTION
Closes #1

Additions:
- [composer] PHPUnit test dependency
- [make] test target
- [tests] basic Netscape bookmarke parsing
- [travis] configuration file

Modifications:
- update LICENSE
