### PR TITLE
parsing: fix ADD_DATE matching & add Unix timestamp support

### DIFF
--- a/parse_netscape_bookmarks.php
+++ b/parse_netscape_bookmarks.php
@@ -86,7 +86,7 @@ function parse_netscape_bookmarks($bkmk_str, $default_tag = null) {
             }
 
             if (preg_match('/add_date="(.*?)"/i', $line, $m8)) {
-                 $items[$i]['time'] = strtotime($m8[0]) ?: time();
+                $items[$i]['time'] = parse_bookmark_date($m8[1]);
             } else {
                 $items[$i]['time'] = time();
             }
@@ -103,4 +103,29 @@ function parse_netscape_bookmarks($bkmk_str, $default_tag = null) {
     ksort($items);
 
     return $items;
+}
+
+
+/**
+ * Parses a formatted date
+ *
+ * @see http://php.net/manual/en/datetime.formats.compound.php
+ * @see http://php.net/manual/en/function.strtotime.php
+ *
+ * @param string $date formatted date
+ *
+ * @return int Unix timestamp corresponding to a successfully parsed date,
+ *             else current date and time
+ */
+function parse_bookmark_date($date)
+{
+    if (strtotime('@'.$date)) {
+        # Unix timestamp
+        return strtotime('@'.$date);
+    } else if (strtotime($date)) {
+        # attempt to parse a known compound date/time format
+        return strtotime($date);
+    }
+    # current date & time
+    return time();
 }

--- a/tests/ParseNetscapeBookmarksTest.php
+++ b/tests/ParseNetscapeBookmarksTest.php
@@ -21,6 +21,7 @@ class ParseNetscapeBookmarksTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Secret stuff', $bkm[0]['title']);
         $this->assertEquals(0, $bkm[0]['pub']);
         $this->assertEquals('private secret', $bkm[0]['tags']);
+        $this->assertEquals('971175336', $bkm[0]['time']);
         $this->assertEquals(
             'Super-secret stuff you\'re not supposed to know about',
             $bkm[0]['note']
@@ -29,6 +30,45 @@ class ParseNetscapeBookmarksTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Public stuff', $bkm[1]['title']);
         $this->assertEquals(1, $bkm[1]['pub']);
         $this->assertEquals('public hello world', $bkm[1]['tags']);
+        $this->assertEquals('1456433748', $bkm[1]['time']);
         $this->assertEquals('', $bkm[1]['note']);
+    }
+
+    /**
+     * Parse log dates
+     */
+    public function test_parse_log_dates()
+    {
+        $this->assertEquals(
+            '971211336',
+            parse_bookmark_date('10/Oct/2000:13:55:36 -0700')
+        );
+        $this->assertEquals(
+            '971186136',
+            parse_bookmark_date('10/Oct/2000:13:55:36 +0000')
+        );
+        $this->assertEquals(
+            '971175336',
+            parse_bookmark_date('10/Oct/2000:13:55:36 +0300')
+        );
+    }
+
+    /**
+     * Parse Unix timestamps
+     */
+    public function test_parse_unix_dates()
+    {
+        $this->assertEquals(
+            '1456433748',
+            parse_bookmark_date('1456433748')
+        );
+        $this->assertEquals(
+            '971175336',
+            parse_bookmark_date('971175336')
+        );
+        $this->assertEquals(
+            '-371211336',
+            parse_bookmark_date('-371211336')
+        );
     }
 }

--- a/tests/input/netscape_basic.htm
+++ b/tests/input/netscape_basic.htm
@@ -5,7 +5,7 @@ Do Not Edit! -->
 <TITLE>Bookmarks</TITLE>
 <H1>Bookmarks</H1>
 <DL><p>
-<DT><A HREF="https://private.tld" ADD_DATE="" PRIVATE="1" TAGS="private secret">Secret stuff</A>
+<DT><A HREF="https://private.tld" ADD_DATE="10/Oct/2000:13:55:36 +0300" PRIVATE="1" TAGS="private secret">Secret stuff</A>
 <DD>Super-secret stuff you're not supposed to know about
-<DT><A HREF="http://public.tld" ADD_DATE="" PRIVATE="0" TAGS="public hello world">Public stuff</A>
+<DT><A HREF="http://public.tld" ADD_DATE="1456433748" PRIVATE="0" TAGS="public hello world">Public stuff</A>
 </DL><p>


### PR DESCRIPTION
Fixes #8

Fixes:
- [parsing] use the proper match for ADD_DATE
- [parsing] do not attempt to convert Unix timestamps

Modifications:
- [parsing] move date parsing to a dedicated function

Additions:
- [tests] add dates to the Netscape input file
- [tests] add coverage for date parsing
