### PR TITLE
parsing: support multiline DD descriptions

### DIFF
--- a/parse_netscape_bookmarks.php
+++ b/parse_netscape_bookmarks.php
@@ -7,7 +7,7 @@ function parse_netscape_bookmarks($bkmk_str, $default_tag = null) {
 
     $current_tag = $default_tag = $default_tag ?: 'imported-'.date("Ymd");
 
-    $bkmk_str = str_replace(array("\r","\n","\t"), array('','',' '), $bkmk_str);
+    $bkmk_str = str_replace(array("\r", "\t"), array('',' '), $bkmk_str);
 
     $bkmk_str = preg_replace_callback('@<dd>(.*?)(<A|<\/|<DL|<DT|<P)@mis', function($m) {
         return '<dd>'.str_replace(array("\r", "\n"), array('', '<br>'), trim($m[1])).'</';

--- a/tests/ParseNetscapeBookmarksTest.php
+++ b/tests/ParseNetscapeBookmarksTest.php
@@ -35,6 +35,27 @@ class ParseNetscapeBookmarksTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Parse a Netscape file containing multiline descriptions
+     */
+    public function test_parse_multiline_descriptions()
+    {
+        $bkm = parse_netscape_bookmarks(
+            file_get_contents('tests/input/netscape_multiline.htm')
+        );
+        $this->assertEquals(2, sizeof($bkm));
+        $this->assertEquals(
+            'List:'.PHP_EOL.'- item1'.PHP_EOL.'- item2'.PHP_EOL.'- item3',
+            $bkm[0]['note']
+        );
+        $this->assertEquals(
+            'Nested lists:'
+           .PHP_EOL.'- list1'.PHP_EOL.'  - item1.1'.PHP_EOL.'  - item1.2'.PHP_EOL.'  - item1.3'
+           .PHP_EOL.'- list2'.PHP_EOL.'  - item2.1',
+            $bkm[1]['note']
+        );
+    }
+
+    /**
      * Parse log dates
      */
     public function test_parse_log_dates()

--- a/tests/input/netscape_multiline.htm
+++ b/tests/input/netscape_multiline.htm
@@ -1,0 +1,21 @@
+<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<!-- This is an automatically generated file.
+It will be read and overwritten.
+Do Not Edit! -->
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+<DT><A HREF="http://multi.li.ne/1" ADD_DATE="1456433741" PRIVATE="0" TAGS="multi">Multiline desc</A>
+<DD>List:
+- item1
+- item2
+- item3
+<DT><A HREF="http://multi.li.ne/2" ADD_DATE="1456433742" PRIVATE="0" TAGS="multi">Multiline desc</A>
+<DD>Nested lists:
+- list1
+  - item1.1
+  - item1.2
+  - item1.3
+- list2
+  - item2.1
+</DL><p>


### PR DESCRIPTION
Closes #7

Modifications:
- [parsing] do not remove all "\n" from the original file
- [tests] add coverage & input data for multiline descriptions
