### PR TITLE
Add test coverage for nested bookmarks

### DIFF
--- a/NetscapeBookmarkParser.php
+++ b/NetscapeBookmarkParser.php
@@ -83,7 +83,7 @@ class NetscapeBookmarkParser
                 // - links may be grouped in a (sub-)folder
                 // - set the header's content as the current tag
                 //   - child links: use this value if the tag list is empty
-                $currentTag = $m1[2];
+                $currentTag = $m1[1];
                 continue;
 
             } elseif (preg_match('/^<\/DL>/i', $line)) {

--- a/tests/ParseNetscapeBookmarksTest.php
+++ b/tests/ParseNetscapeBookmarksTest.php
@@ -75,6 +75,47 @@ class ParseNetscapeBookmarksTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Parse bookmarks nested in folders
+     */
+    public function testParseNested()
+    {
+        $bkm = $this->parser->parseFile('tests/input/netscape_nested.htm');
+        $this->assertEquals(8, sizeof($bkm));
+
+        $this->assertEquals('tag1 tag2', $bkm[0]['tags']);
+        $this->assertEquals('1456433741', $bkm[0]['time']);
+        $this->assertEquals('Nested 1', $bkm[0]['title']);
+
+        $this->assertEquals('tag1 tag2', $bkm[1]['tags']);
+        $this->assertEquals('1456433742', $bkm[1]['time']);
+        $this->assertEquals('Nested 1-1', $bkm[1]['title']);
+
+        $this->assertEquals('tag3 tag4', $bkm[2]['tags']);
+        $this->assertEquals('1456433747', $bkm[2]['time']);
+        $this->assertEquals('Nested 1-2', $bkm[2]['title']);
+
+        $this->assertEquals('Folder2', $bkm[3]['tags']);
+        $this->assertEquals('1454433742', $bkm[3]['time']);
+        $this->assertEquals('Nested 2-1', $bkm[3]['title']);
+
+        $this->assertEquals('Folder2', $bkm[4]['tags']);
+        $this->assertEquals('1453233747', $bkm[4]['time']);
+        $this->assertEquals('Nested 2-2', $bkm[4]['title']);
+
+        $this->assertEquals('tag3', $bkm[5]['tags']);
+        $this->assertEquals('1454433742', $bkm[5]['time']);
+        $this->assertEquals('Nested 3-1', $bkm[5]['title']);
+
+        $this->assertEquals('Folder3-1', $bkm[6]['tags']);
+        $this->assertEquals('1453233747', $bkm[6]['time']);
+        $this->assertEquals('Nested 3-2', $bkm[6]['title']);
+
+        $this->assertEquals('tag4', $bkm[7]['tags']);
+        $this->assertEquals('1456733741', $bkm[7]['time']);
+        $this->assertEquals('Nested 2', $bkm[7]['title']);
+    }
+
+    /**
      * Parse boolean attribute values - evaluating to TRUE
      */
     function testParseBooleanAttributesTrue()

--- a/tests/input/netscape_nested.htm
+++ b/tests/input/netscape_nested.htm
@@ -1,0 +1,28 @@
+<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<!-- This is an automatically generated file.
+It will be read and overwritten.
+Do Not Edit! -->
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+  <DT><A HREF="http://nest.ed/1" ADD_DATE="1456433741" PRIVATE="0" TAGS="tag1,tag2">Nested 1</A>
+  <DT><H3>Folder1</H3>
+  <DL><p>
+    <DT><A HREF="http://nest.ed/1-1" ADD_DATE="1456433742" PRIVATE="0" TAGS="tag1,tag2">Nested 1-1</A>
+    <DT><A HREF="http://nest.ed/1-2" ADD_DATE="1456433747" PRIVATE="0" TAGS="tag3,tag4">Nested 1-2</A>
+  </DL><p>
+  <DT><H3>Folder2</H3>
+  <DL><p>
+    <DT><A HREF="http://nest.ed/2-1" ADD_DATE="1454433742" PRIVATE="0">Nested 2-1</A>
+    <DT><A HREF="http://nest.ed/2-2" ADD_DATE="1453233747" PRIVATE="0">Nested 2-2</A>
+  </DL><p>
+  <DT><H3>Folder3</H3>
+  <DL><p>
+    <DT><H3>Folder3-1</H3>
+    <DL><p>
+      <DT><A HREF="http://nest.ed/3-1" ADD_DATE="1454433742" PRIVATE="0" TAGS="tag3">Nested 3-1</A>
+      <DT><A HREF="http://nest.ed/3-2" ADD_DATE="1453233747" PRIVATE="0">Nested 3-2</A>
+    </DL><p>
+  </DL><p>
+  <DT><A HREF="http://nest.ed/2" ADD_DATE="1456733741" PRIVATE="0" TAGS="tag4">Nested 2</A>
+</DL><p>


### PR DESCRIPTION
This test highlights how the parser handles bookmarks organized by (sub-)folders.

Relates to https://github.com/shaarli/netscape-bookmark-parser/issues/16
Relates to https://github.com/shaarli/netscape-bookmark-parser/issues/14
