### PR TITLE
Refactor the bookmark sanitizing function

### DIFF
--- a/tests/input/netscape_nested.htm
+++ b/tests/input/netscape_nested.htm
@@ -15,7 +15,9 @@ Do Not Edit! -->
   <DD>This second folder contains wonderful links!
   <DL><p>
     <DT><A HREF="http://nest.ed/2-1" ADD_DATE="1454433742" PRIVATE="0">Nested 2-1</A>
+    <DD>First link of the second section
     <DT><A HREF="http://nest.ed/2-2" ADD_DATE="1453233747" PRIVATE="0">Nested 2-2</A>
+    <DD>Second link of the second section
   </DL><p>
   <DT><H3>Folder3</H3>
   <DL><p>


### PR DESCRIPTION
Closes #17

Modifications:
- remove unnecessary regex matches
- simplify substitution patterns
- group substitutions by operation type
- add comments for human beings (most of whom are not fluent in regex)

Fix:
- nested bookmarks where an entry's description precedes a subsection's header, i.e.:
  
  ``` xml
  <A HREF="...">My Link</A>
  <DD>Some description
  <DT><H3>Subsection</H3>
  <DL><p>
  ```
