### PR TITLE
parsing: strip punctuation from tags derived from nested folder names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v2.0.3](https://github.com/shaarli/netscape-bookmark-parser/releases/tag/v2.0.3) - UNPUBLISHED
+### Changed
+- Update nested folder name parsing to sanitize resulting tags
+
+
 ## [v2.0.2](https://github.com/shaarli/netscape-bookmark-parser/releases/tag/v2.0.2) - 2017-06-10
 ### Changed
 - Update note/description parsing to support Scuttle exports

--- a/tests/ParseNetscapeBookmarksTest.php
+++ b/tests/ParseNetscapeBookmarksTest.php
@@ -335,4 +335,30 @@ class ParseNetscapeBookmarksTest extends \PHPUnit_Framework_TestCase
             $bkm[0]['tags']
         );
     }
+
+    /**
+     * Sanitize tags derived from bookmark folder names
+     */
+    public function testSanitizeFolderTagString()
+    {
+        $this->assertEquals('', $this->parser->sanitizeTagString(''));
+
+        $this->assertEquals(
+            'hello',
+            $this->parser->sanitizeTagString('-hello')
+        );
+        $this->assertEquals(
+            'hello',
+            $this->parser->sanitizeTagString('_hello')
+        );
+
+        $this->assertEquals(
+            'hello world',
+            $this->parser->sanitizeTagString('-hello$, WOrld')
+        );
+        $this->assertEquals(
+            'hello world',
+            $this->parser->sanitizeTagString('-Hello$ - WOrlD!')
+        );
+    }
 }

--- a/tests/ParseSafariBookmarksTest.php
+++ b/tests/ParseSafariBookmarksTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Shaarli\NetscapeBookmarkParser;
+
+/**
+ * Ensure Safari exports are properly parsed
+ */
+class ParseSafariBookmarksTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Delete log file.
+     */
+    public function tearDown()
+    {
+        @unlink(LoggerTestsUtils::getLogFile());
+    }
+
+    /**
+     * Parse bookmarks as exported by Safari - Strip punctuation from folder names
+     */
+    public function testParseFoldedStripPunctuation()
+    {
+        $parser = new NetscapeBookmarkParser();
+        $bkm = $parser->parseFile('tests/input/safari_folded.htm');
+        $this->assertEquals(3, sizeof($bkm));
+
+        $this->assertEquals('', $bkm[0]['note']);
+        $this->assertEquals('0', $bkm[0]['pub']);
+        $this->assertEquals('favoris', $bkm[0]['tags']);
+        $this->assertEquals('GitHub', $bkm[0]['title']);
+        $this->assertEquals('https://github.com/', $bkm[0]['uri']);
+
+        $this->assertEquals('', $bkm[1]['note']);
+        $this->assertEquals('0', $bkm[1]['pub']);
+        $this->assertEquals('github shaarli', $bkm[1]['tags']);
+        $this->assertEquals(
+            'GitHub - shaarli/Shaarli:'
+           .' The personal, minimalist, super-fast, database free,'
+           .' bookmarking service - community repo',
+            $bkm[1]['title']
+        );
+        $this->assertEquals('https://github.com/shaarli/Shaarli', $bkm[1]['uri']);
+
+        $this->assertEquals('', $bkm[2]['note']);
+        $this->assertEquals('0', $bkm[2]['pub']);
+        $this->assertEquals('autre divers doc', $bkm[2]['tags']);
+        $this->assertEquals(
+            'Wikipedia, the free encyclopedia',
+            $bkm[2]['title']
+        );
+        $this->assertEquals(
+            'https://en.wikipedia.org/wiki/Main_Page',
+            $bkm[2]['uri']
+        );
+    }
+}

--- a/tests/input/safari_folded.htm
+++ b/tests/input/safari_folded.htm
@@ -1,0 +1,24 @@
+<!DOCTYPE NETSCAPE-Bookmark-file-1>
+	<HTML>
+	<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+	<Title>Signets</Title>
+	<H1>Signets</H1>
+	<DT><H3 FOLDED>Favoris</H3>
+	<DL><p>
+		<DT><A HREF="https://github.com/">GitHub</A>
+	</DL><p>
+	<DT><H3 FOLDED>Menu Signets</H3>
+	<DL><p>
+	</DL><p>
+	<DT><H3 FOLDED>Github - Shaarli</H3>
+	<DL><p>
+		<DT><A HREF="https://github.com/shaarli/Shaarli">GitHub - shaarli/Shaarli: The personal, minimalist, super-fast, database free, bookmarking service - community repo</A>
+	</DL><p>
+	<DT><H3 FOLDED>Autre Divers</H3>
+	<DL><p>
+		<DT><H3 FOLDED>doc</H3>
+		<DL><p>
+			<DT><A HREF="https://en.wikipedia.org/wiki/Main_Page">Wikipedia, the free encyclopedia</A>
+		</DL><p>
+	</DL><p>
+</HTML>


### PR DESCRIPTION
Fixes https://github.com/shaarli/Shaarli/issues/892

See:
- https://stackoverflow.com/questions/16426976/php-regular-expression-remove-all-non-alphanumeric-characters