### PR TITLE
Improve sanitizing regexp

### DIFF
--- a/NetscapeBookmarkParser.php
+++ b/NetscapeBookmarkParser.php
@@ -262,7 +262,7 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
         $sanitized = $bookmarkString;
 
         // trim comments
-        $sanitized = preg_replace('@<!--.*-->@mis', '', $sanitized);
+        $sanitized = preg_replace('@<!--.*?-->@mis', '', $sanitized);
 
         // keep one XML element per line to prepare for linear parsing
         $sanitized = preg_replace('@>(\s*?)<@mis', ">\n<", $sanitized);
@@ -279,9 +279,9 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
         // convert multiline descriptions to one-line descriptions
         // line feeds are converted to <br>
         $sanitized = preg_replace_callback(
-            '@<DD>(.*?)<@mis',
+            '@<DD>(.*?)(</?(:?DT|DD|DL))@mis',
             function($match) {
-                return '<DD>'.str_replace("\n", '<br>', trim($match[1])).PHP_EOL.'<';
+                return '<DD>'.str_replace("\n", '<br>', trim($match[1])).PHP_EOL. $match[2];
             },
             $sanitized
         );

--- a/tests/ParseDeliciousBookmarksTest.php
+++ b/tests/ParseDeliciousBookmarksTest.php
@@ -59,4 +59,43 @@ class ParseDeliciousBookmarksTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertEquals('1412085559', $bkm[4]['time']);
     }
+
+    /**
+     * Make sure that the sanitizing function doesn't strip content
+     */
+    public function testParseStrictSanitizing()
+    {
+        $parser = new NetscapeBookmarkParser();
+        $bkm = $parser->parseFile('tests/input/delicious_sanitize.htm');
+        $this->assertEquals(2, sizeof($bkm));
+
+        $this->assertEquals(
+            'Text
+<li>#CLE ---> #VALEUR</li>
+</BOUCLE_exploiter>
+</code>',
+            $bkm[0]['note']
+        );
+        $this->assertEquals('1', $bkm[0]['pub']);
+        $this->assertEquals('1380651656', $bkm[0]['time']);
+        $this->assertEquals('http://spip.pastebin.fr/28921', $bkm[0]['uri']);
+        $this->assertEquals(
+            'spip pastebin - outil de debug collaboratif - Bonjour les écureuils !',
+            $bkm[0]['title']
+        );
+        $this->assertEquals('spip3   astuces ', $bkm[0]['tags']);
+
+        $this->assertEquals('1', $bkm[1]['pub']);
+        $this->assertEquals('1380651611', $bkm[1]['time']);
+        $this->assertEquals(
+            'http://www.la-grange.net/2013/09/07/changement',
+            $bkm[1]['uri']
+        );
+        $this->assertEquals('Changer le monde - Carnets Web de La Grange', $bkm[1]['title']);
+        $this->assertEquals(
+            'La juxtaposition des mots propriétés et intellectuel (du monde des idées) '
+           .'est une aberration dans un contexte de l\'échange et de la culture.',
+            $bkm[1]['note']
+        );
+    }
 }

--- a/tests/input/delicious_sanitize.htm
+++ b/tests/input/delicious_sanitize.htm
@@ -1,0 +1,16 @@
+<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<!-- This is an automatically generated file.
+It will be read and overwritten.
+Do Not Edit! -->
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+<DT><A HREF="http://spip.pastebin.fr/28921" ADD_DATE="1380651656" PRIVATE="0" TAGS="spip3 , astuces ">spip pastebin - outil de debug collaboratif - Bonjour les écureuils !</A>
+<DD>Text
+<li>#CLE ---> #VALEUR</li>
+</BOUCLE_exploiter>
+</code>
+<DT><A HREF="http://www.la-grange.net/2013/09/07/changement" ADD_DATE="1380651611" PRIVATE="0" TAGS="culture , propriété_intellectuelle , ChangerLeMonde ">Changer le monde - Carnets Web de La Grange</A>
+<DD>La juxtaposition des mots propriétés et intellectuel (du monde des idées) est une aberration dans un contexte de l'échange et de la culture.
+</DL><p>


### PR DESCRIPTION
  - less permissive comment trim to avoid stripping a LOT of content
  - link descriptions: match a Netscape tag to detect the end instead of any tag

Fixes shaarli/Shaarli#902

TODO: 
  - [x] unit tests