### PR TITLE
Normalize dates to Unix timestamps in _seconds_

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig: http://EditorConfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{htm,html,xml,yml}]
+indent_size = 2
+
+[*.php]
+max_line_length = 100
+
+[Makefile]
+indent_style = tab

--- a/NetscapeBookmarkParser.php
+++ b/NetscapeBookmarkParser.php
@@ -15,6 +15,8 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
     protected $keepNestedTags;
     protected $defaultTags;
     protected $defaultPub;
+    protected $normalizeDates;
+    protected $dateDeltaYears;
     protected $items;
 
     /**
@@ -34,12 +36,17 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
      *                               - '1' => public
      *                               - '0' => private)
      * @param string $logDir         Log directory
+     * @param bool   $normalizeDates Whether parsed dates are expected to fall within
+     *                               a given time interval
+     * @param int    $dateDeltaYears Delta used to compute the "acceptable" date interval
      */
     public function __construct(
         $keepNestedTags=true,
         $defaultTags=array(),
         $defaultPub='0',
-        $logDir=null
+        $logDir=null,
+        $normalizeDates=true,
+        $dateDeltaYears=30
     )
     {
         if ($keepNestedTags) {
@@ -60,6 +67,9 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
                 'extension' => 'log',
             )
         ));
+
+        $this->normalizeDates = $normalizeDates;
+        $this->dateDeltaYears = $dateDeltaYears;
     }
 
     /**
@@ -206,18 +216,57 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
      * @return int Unix timestamp corresponding to a successfully parsed date,
      *             else current date and time
      */
-    public static function parseDate($date)
+    public function parseDate($date)
     {
         if (strtotime('@'.$date)) {
             // Unix timestamp
+            if ($this->normalizeDates) {
+                $date = $this->normalizeDate($date);
+            }
             return strtotime('@'.$date);
         } else if (strtotime($date)) {
             // attempt to parse a known compound date/time format
             return strtotime($date);
         }
         // current date & time
-        return time();
+        return $time;
     }
+
+    /**
+     * Normalizes a date by supposing it is comprised in a given range
+     *
+     * Although most bookmarking services return dates formatted as a Unix epoch
+     * (seconds elapsed since 1970-01-01 00:00:00) or human-readable strings,
+     * some services return microtime epochs (microseconds elapsed since
+     * 1970-01-01 00:00:00.000000) WITHOUT using a delimiter for the microseconds
+     * part...
+     *
+     * This is likely to raise issues in the distant future!
+     *
+     * @see https://stackoverflow.com/questions/33691428/datetime-with-microseconds
+     * @see https://stackoverflow.com/questions/23929145/how-to-test-if-a-given-time-stamp-is-in-seconds-or-milliseconds
+     * @see https://stackoverflow.com/questions/539900/google-bookmark-export-date-format
+     * @see https://www.wired.com/2010/11/1110mars-climate-observer-report/
+     *
+     * @param string $epoch     Unix timestamp to normalize
+     *
+     * @return string Unix timestamp in seconds, within the expected range
+     */
+    public function normalizeDate($epoch) {
+        $now = new \DateTime();
+        $range = new \DateInterval('P'.$this->dateDeltaYears.'Y');
+        $maxDate = $now->add($range);
+
+        $date = new \DateTime('@'.$epoch);
+
+        for ($i = 1; $date > $maxDate; $i++) {
+            // trim the provided date until it falls within the expected range
+            $date = new \DateTime('@'.substr($epoch, 0, strlen($epoch) - $i));
+        }
+
+        return $date->getTimestamp();
+    }
+
 
     /**
      * Parses the value of a supposedly boolean attribute

--- a/NetscapeBookmarkParser.php
+++ b/NetscapeBookmarkParser.php
@@ -16,7 +16,7 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
     protected $defaultTags;
     protected $defaultPub;
     protected $normalizeDates;
-    protected $dateDeltaYears;
+    protected $dateRange;
     protected $items;
 
     /**
@@ -37,8 +37,8 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
      *                               - '0' => private)
      * @param string $logDir         Log directory
      * @param bool   $normalizeDates Whether parsed dates are expected to fall within
-     *                               a given time interval
-     * @param int    $dateDeltaYears Delta used to compute the "acceptable" date interval
+     *                               a given date/time interval
+     * @param string $dateRange      Delta used to compute the "acceptable" date/time interval
      */
     public function __construct(
         $keepNestedTags=true,
@@ -46,7 +46,7 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
         $defaultPub='0',
         $logDir=null,
         $normalizeDates=true,
-        $dateDeltaYears=30
+        $dateRange='30 years'
     )
     {
         if ($keepNestedTags) {
@@ -69,7 +69,7 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
         ));
 
         $this->normalizeDates = $normalizeDates;
-        $this->dateDeltaYears = $dateDeltaYears;
+        $this->dateRange = $dateRange;
     }
 
     /**
@@ -253,11 +253,8 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
      * @return string Unix timestamp in seconds, within the expected range
      */
     public function normalizeDate($epoch) {
-        $now = new \DateTime();
-        $range = new \DateInterval('P'.$this->dateDeltaYears.'Y');
-        $maxDate = $now->add($range);
-
         $date = new \DateTime('@'.$epoch);
+        $maxDate = new \DateTime('+'.$this->dateRange);
 
         for ($i = 1; $date > $maxDate; $i++) {
             // trim the provided date until it falls within the expected range

--- a/tests/ParseGoogleBookmarksTest.php
+++ b/tests/ParseGoogleBookmarksTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Shaarli\NetscapeBookmarkParser;
+
+/**
+ * Ensure Google Bookmarks exports are properly parsed
+ *
+ * The reference data has been dumped with Google Bookmarks on 2018-10-01
+ */
+class ParseGoogleBookmarksTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Delete log file.
+     */
+    public function tearDown()
+    {
+        @unlink(LoggerTestsUtils::getLogFile());
+    }
+
+    /**
+     * Parse nested Google Bookmarks (directories and subdirectories)
+     */
+    public function testParseNested()
+    {
+        $parser = new NetscapeBookmarkParser(true, null, '1');
+        $bkm = $parser->parseFile('tests/input/google_bookmarks_nested.htm');
+        $this->assertEquals(6, sizeof($bkm));
+
+        $this->assertEquals('', $bkm[0]['note']);
+        $this->assertEquals('1', $bkm[0]['pub']);
+        $this->assertEquals('unlabeled', $bkm[0]['tags']);
+        $this->assertEquals('1515515697', $bkm[0]['time']);
+        $this->assertEquals(
+            'WordHippo | Comprehensive Thesaurus for Synonyms and Antonyms',
+            $bkm[0]['title']
+        );
+        $this->assertEquals('https://www.wordhippo.com/', $bkm[0]['uri']);
+
+        $this->assertequals('', $bkm[1]['note']);
+        $this->assertequals('1', $bkm[1]['pub']);
+        $this->assertequals('unlabeled', $bkm[1]['tags']);
+        $this->assertequals('1519067075', $bkm[1]['time']);
+        $this->assertequals(
+            'powershell - Move files into alphabetically named folders - Stack Overflow',
+            $bkm[1]['title']
+        );
+        $this->assertequals(
+            'https://stackoverflow.com/questions/20180072/'
+            .'move-files-into-alphabetically-named-folders',
+            $bkm[1]['uri']
+        );
+
+        $this->assertequals('', $bkm[2]['note']);
+        $this->assertequals('1', $bkm[2]['pub']);
+        $this->assertequals('unlabeled', $bkm[2]['tags']);
+        $this->assertequals('1523996185', $bkm[2]['time']);
+        $this->assertequals('Free Lien Search', $bkm[2]['title']);
+        $this->assertequals('http://www.searchq.com/', $bkm[2]['uri']);
+
+        $this->assertequals('', $bkm[3]['note']);
+        $this->assertequals('1', $bkm[3]['pub']);
+        $this->assertequals('unlabeled', $bkm[3]['tags']);
+        $this->assertequals('1529505663', $bkm[3]['time']);
+        $this->assertequals('OpenNIC Project', $bkm[3]['title']);
+        $this->assertequals('https://www.opennic.org/', $bkm[3]['uri']);
+
+        $this->assertequals('', $bkm[4]['note']);
+        $this->assertequals('1', $bkm[4]['pub']);
+        $this->assertequals('unlabeled', $bkm[4]['tags']);
+        $this->assertequals('1532442262', $bkm[4]['time']);
+        $this->assertequals('Kubo and the Two Strings (2016) - IMDb', $bkm[4]['title']);
+        $this->assertequals('https://www.imdb.com/title/tt4302938/', $bkm[4]['uri']);
+
+        $this->assertequals('', $bkm[5]['note']);
+        $this->assertequals('1', $bkm[5]['pub']);
+        $this->assertequals('unlabeled', $bkm[5]['tags']);
+        $this->assertequals('1523996194', $bkm[5]['time']);
+        $this->assertequals('Home | NextAce', $bkm[5]['title']);
+        $this->assertequals('https://nextace.com/', $bkm[5]['uri']);
+    }
+}

--- a/tests/input/google_bookmarks_nested.htm
+++ b/tests/input/google_bookmarks_nested.htm
@@ -1,0 +1,14 @@
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+<DT><H3 ADD_DATE="1523996194943160">Unlabeled</H3>
+<DL><p>
+<DT><A HREF="https://www.wordhippo.com/" ADD_DATE="1515515697780642">WordHippo | Comprehensive Thesaurus for Synonyms and Antonyms</A>
+<DT><A HREF="https://stackoverflow.com/questions/20180072/move-files-into-alphabetically-named-folders" ADD_DATE="1519067075550809">powershell - Move files into alphabetically named folders - Stack Overflow</A>
+<DT><A HREF="http://www.searchq.com/" ADD_DATE="1523996185317575">Free Lien Search</A>
+<DT><A HREF="https://www.opennic.org/" ADD_DATE="1529505663052547">OpenNIC Project</A>
+<DT><A HREF="https://www.imdb.com/title/tt4302938/" ADD_DATE="1532442262578515">Kubo and the Two Strings (2016) - IMDb</A>
+<DT><A HREF="https://nextace.com/" ADD_DATE="1523996194943160">Home | NextAce</A>
+</DL><p>
+</DL><p>


### PR DESCRIPTION
TL;DR: Always use units when expressing data. Units are good.

Relates to shaarli/Shaarli#1227

Although most bookmarking services return dates formatted as a Unix epoch (seconds elapsed since `1970-01-01 00:00:00`) or human-readable strings, some services return microtime epochs (microseconds elapsed since `1970-01-01 00:00:00.000000`) WITHOUT using a delimiter for the microseconds part...

This PR adds some guesswork to the date parser so results fall within a resonable range, e.g.:

> `now - 30 years < parsed date < now + 30 years`

This is likely to raise issues in the distant future!

See:
- https://stackoverflow.com/questions/33691428/datetime-with-microseconds
- https://stackoverflow.com/questions/23929145/how-to-test-if-a-given-time-stamp-is-in-seconds-or-milliseconds
- https://stackoverflow.com/questions/539900/google-bookmark-export-date-format
- https://www.wired.com/2010/11/1110mars-climate-observer-report/