### PR TITLE
PHP 7.3: fix regex syntax

### DIFF
--- a/NetscapeBookmarkParser.php
+++ b/NetscapeBookmarkParser.php
@@ -329,7 +329,7 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
             $value = preg_replace('/^[[:punct:]]/', '', $value);
 
             // trim all but alphanumeric characters, underscores and non-leading dashes
-            $value = preg_replace('/[^\p{L}\p{N}-_]++/u', '', $value);
+            $value = preg_replace('/[^\p{L}\p{N}\-_]++/u', '', $value);
 
             if ($value == '') {
                 unset($tags[$key]);


### PR DESCRIPTION
Tested against PHP 7.3 RC1 with Travis. Not sure what changed exactly.

```
There was 1 error:
1) BookmarkImportTest::testImportNested
preg_replace(): Compilation failed: invalid range in character class at offset 12
/home/travis/build/ArthurHoaro/Shaarli/vendor/shaarli/netscape-bookmark-parser/NetscapeBookmarkParser.php:332
/home/travis/build/ArthurHoaro/Shaarli/vendor/shaarli/netscape-bookmark-parser/NetscapeBookmarkParser.php:118
/home/travis/build/ArthurHoaro/Shaarli/application/NetscapeBookmarkUtils.php:146
/home/travis/build/ArthurHoaro/Shaarli/tests/NetscapeBookmarkUtils/BookmarkImportTest.php:182
```

