### PR TITLE
Update tests to run on phpunit 6 or later

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,6 @@
         "katzgrau/klogger": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0"
+        "phpunit/phpunit": "^6.0"
     }
 }

--- a/tests/ImportLoggerTest.php
+++ b/tests/ImportLoggerTest.php
@@ -10,7 +10,7 @@ use Psr\Log\LogLevel;
  *
  * Make sure that the log file is correctly generated.
  */
-class ImportLoggerTest extends \PHPUnit_Framework_TestCase
+class ImportLoggerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var NetscapeBookmarkParser instance
@@ -20,7 +20,7 @@ class ImportLoggerTest extends \PHPUnit_Framework_TestCase
     /**
      * Initialize test resources
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = new NetscapeBookmarkParser();
     }
@@ -28,7 +28,7 @@ class ImportLoggerTest extends \PHPUnit_Framework_TestCase
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
         @unlink(LoggerTestsUtils::getLogFile('tmp'));

--- a/tests/ParseChromiumBookmarksTest.php
+++ b/tests/ParseChromiumBookmarksTest.php
@@ -7,12 +7,12 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * The reference data has been dumped with Chromium 51.0.2704.84
  */
-class ParseChromiumBookmarksTest extends \PHPUnit_Framework_TestCase
+class ParseChromiumBookmarksTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/ParseDeliciousBookmarksTest.php
+++ b/tests/ParseDeliciousBookmarksTest.php
@@ -7,12 +7,12 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * @see http://delicious.com/
  */
-class ParseDeliciousBookmarksTest extends \PHPUnit_Framework_TestCase
+class ParseDeliciousBookmarksTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/ParseFirefoxBookmarksTest.php
+++ b/tests/ParseFirefoxBookmarksTest.php
@@ -7,12 +7,12 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * The reference data has been dumped with Mozilla Firefox 46.0.1
  */
-class ParseFirefoxBookmarksTest extends \PHPUnit_Framework_TestCase
+class ParseFirefoxBookmarksTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/ParseGoogleBookmarksTest.php
+++ b/tests/ParseGoogleBookmarksTest.php
@@ -7,12 +7,12 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * The reference data has been dumped with Google Bookmarks on 2018-10-01
  */
-class ParseGoogleBookmarksTest extends \PHPUnit_Framework_TestCase
+class ParseGoogleBookmarksTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/ParseInternetExplorerBookmarksTest.php
+++ b/tests/ParseInternetExplorerBookmarksTest.php
@@ -7,14 +7,14 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * The reference data has been dumped with IE 11
  */
-class ParseInternetExplorerBookmarksTest extends \PHPUnit_Framework_TestCase
+class ParseInternetExplorerBookmarksTest extends \PHPUnit\Framework\TestCase
 {
     protected $parser = null;
 
     /**
      * Initialize test resources
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = new NetscapeBookmarkParser(true, array(), 'error');
     }
@@ -22,7 +22,7 @@ class ParseInternetExplorerBookmarksTest extends \PHPUnit_Framework_TestCase
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/ParseNetscapeBookmarksTest.php
+++ b/tests/ParseNetscapeBookmarksTest.php
@@ -8,14 +8,14 @@ namespace Shaarli\NetscapeBookmarkParser;
  * @see https://msdn.microsoft.com/en-us/library/aa753582%28v=vs.85%29.aspx
  * @see http://www.w3schools.com/tags/tag_dl.asp
  */
-class ParseNetscapeBookmarksTest extends \PHPUnit_Framework_TestCase
+class ParseNetscapeBookmarksTest extends \PHPUnit\Framework\TestCase
 {
     protected $parser = null;
 
     /**
      * Initialize test resources
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = new NetscapeBookmarkParser(true, array(), 'error');
     }
@@ -23,7 +23,7 @@ class ParseNetscapeBookmarksTest extends \PHPUnit_Framework_TestCase
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/ParseSafariBookmarksTest.php
+++ b/tests/ParseSafariBookmarksTest.php
@@ -5,12 +5,12 @@ namespace Shaarli\NetscapeBookmarkParser;
 /**
  * Ensure Safari exports are properly parsed
  */
-class ParseSafariBookmarksTest extends \PHPUnit_Framework_TestCase
+class ParseSafariBookmarksTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/ParseScuttleBookmarksTest.php
+++ b/tests/ParseScuttleBookmarksTest.php
@@ -7,12 +7,12 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * @see https://sourceforge.net/projects/scuttle/
  */
-class ParseScuttleBookmarksTest extends \PHPUnit_Framework_TestCase
+class ParseScuttleBookmarksTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/ParseShaarliBookmarksTest.php
+++ b/tests/ParseShaarliBookmarksTest.php
@@ -7,14 +7,14 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * @see https://github.com/shaarli/Shaarli
  */
-class ParseShaarliBookmarksTest extends \PHPUnit_Framework_TestCase
+class ParseShaarliBookmarksTest extends \PHPUnit\Framework\TestCase
 {
     protected $parser = null;
 
     /**
      * Initialize test resources
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = new NetscapeBookmarkParser();
     }
@@ -22,7 +22,7 @@ class ParseShaarliBookmarksTest extends \PHPUnit_Framework_TestCase
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }


### PR DESCRIPTION
I'm working on packaging netscape-bookmark-parser for Debian at https://salsa.debian.org/php-team/pear/php-netscape-bookmark-parser. Since Debian unstable has phpunit 8.4.2, I patched the tests to work with that version.

Signed-off-by: James Valleroy <jvalleroy@mailbox.org>