### PR TITLE
Log to current working directory by default

### DIFF
--- a/NetscapeBookmarkParser.php
+++ b/NetscapeBookmarkParser.php
@@ -60,7 +60,7 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
         $this->defaultPub = $defaultPub;
 
         $this->setLogger(new Logger(
-            $logDir == null ? __DIR__ . '/logs/' : $logDir,
+            $logDir == null ? 'logs/' : $logDir,
             LogLevel::INFO,
             array(
                 'prefix' => 'import.',


### PR DESCRIPTION
`__DIR__` refers to the directory where NetscapeBookmarkParser.php is installed, and may not allow writing logs in this location.

In case of the Debian package, `__DIR__` means `/usr/share/php/Shaarli/NetscapeBookmarkParser/`.

Signed-off-by: James Valleroy <jvalleroy@mailbox.org>