### PR TITLE
Fix - Error while trying to import a file without items

### DIFF
--- a/NetscapeBookmarkParser.php
+++ b/NetscapeBookmarkParser.php
@@ -17,7 +17,7 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
     protected $defaultPub;
     protected $normalizeDates;
     protected $dateRange;
-    protected $items;
+    protected $items = [];
 
     /**
      * @var LoggerInterface instance.
@@ -200,6 +200,7 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
                 $i++;
             }
         }
+
         ksort($this->items);
         $this->logger->info('File parsing ended');
         return $this->items;

--- a/tests/ParseEmptyFileTest.php
+++ b/tests/ParseEmptyFileTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Shaarli\NetscapeBookmarkParser;
+
+/**
+ * Ensure that trying to import an empty file is handled properly.
+ */
+class ParseEmptyFileTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Delete log file.
+     */
+    public function tearDown()
+    {
+        @unlink(LoggerTestsUtils::getLogFile());
+    }
+
+    /**
+     * Parse flat Firefox bookmarks (no directories)
+     */
+    public function testParseFlat()
+    {
+        $parser = new NetscapeBookmarkParser();
+        $data = $parser->parseFile('tests/input/empty.htm');
+
+        static::assertTrue(is_array($data));
+        static::assertCount(0, $data);
+    }
+}


### PR DESCRIPTION
If the file provided is empty or does not contain any items, the lib will return an empty array, instead of generating a warning/error.

Fixes #50