### PR TITLE
Drop support for PHP 7.0 and less

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ cache:
   directories:
     - $HOME/.composer/cache
 php:
+  - nightly
+  - 7.4
+  - 7.3
   - 7.2
   - 7.1
-  - 7.0
-  - 5.6
 install:
   - composer self-update
   - composer install --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
         }
     },
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.1",
         "katzgrau/klogger": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,6 @@
         "katzgrau/klogger": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0"
+        "phpunit/phpunit": "^6.0"
     }
 }

--- a/tests/ImportLoggerTest.php
+++ b/tests/ImportLoggerTest.php
@@ -10,7 +10,7 @@ use Psr\Log\LogLevel;
  *
  * Make sure that the log file is correctly generated.
  */
-class ImportLoggerTest extends \PHPUnit_Framework_TestCase
+class ImportLoggerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var NetscapeBookmarkParser instance
@@ -20,7 +20,7 @@ class ImportLoggerTest extends \PHPUnit_Framework_TestCase
     /**
      * Initialize test resources
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = new NetscapeBookmarkParser();
     }
@@ -28,7 +28,7 @@ class ImportLoggerTest extends \PHPUnit_Framework_TestCase
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
         @unlink(LoggerTestsUtils::getLogFile('tmp'));

--- a/tests/ImportLoggerTest.php
+++ b/tests/ImportLoggerTest.php
@@ -10,7 +10,7 @@ use Psr\Log\LogLevel;
  *
  * Make sure that the log file is correctly generated.
  */
-class ImportLoggerTest extends \PHPUnit\Framework\TestCase
+class ImportLoggerTest extends TestCase
 {
     /**
      * @var NetscapeBookmarkParser instance
@@ -43,8 +43,8 @@ class ImportLoggerTest extends \PHPUnit\Framework\TestCase
         $this->parser->parseFile('tests/input/shaarli.htm');
         $this->assertFileExists(LoggerTestsUtils::getLogFile());
         $content = file_get_contents(LoggerTestsUtils::getLogFile());
-        $this->assertContains('[info]', $content);
-        $this->assertNotContains('[debug]', $content);
+        $this->assertContainsPolyfill('[info]', $content);
+        $this->assertNotContainsPolyfill('[debug]', $content);
     }
 
     /**
@@ -64,8 +64,8 @@ class ImportLoggerTest extends \PHPUnit\Framework\TestCase
         $this->parser->parseFile('tests/input/shaarli.htm');
         $this->assertFileExists(LoggerTestsUtils::getLogFile());
         $content = file_get_contents(LoggerTestsUtils::getLogFile());
-        $this->assertContains('[info]', $content);
-        $this->assertContains('[debug]', $content);
+        $this->assertContainsPolyfill('[info]', $content);
+        $this->assertContainsPolyfill('[debug]', $content);
     }
 
     /**

--- a/tests/ParseChromiumBookmarksTest.php
+++ b/tests/ParseChromiumBookmarksTest.php
@@ -7,12 +7,12 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * The reference data has been dumped with Chromium 51.0.2704.84
  */
-class ParseChromiumBookmarksTest extends \PHPUnit_Framework_TestCase
+class ParseChromiumBookmarksTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/ParseChromiumBookmarksTest.php
+++ b/tests/ParseChromiumBookmarksTest.php
@@ -7,7 +7,7 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * The reference data has been dumped with Chromium 51.0.2704.84
  */
-class ParseChromiumBookmarksTest extends \PHPUnit\Framework\TestCase
+class ParseChromiumBookmarksTest extends TestCase
 {
     /**
      * Delete log file.

--- a/tests/ParseDeliciousBookmarksTest.php
+++ b/tests/ParseDeliciousBookmarksTest.php
@@ -7,12 +7,12 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * @see http://delicious.com/
  */
-class ParseDeliciousBookmarksTest extends \PHPUnit_Framework_TestCase
+class ParseDeliciousBookmarksTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/ParseDeliciousBookmarksTest.php
+++ b/tests/ParseDeliciousBookmarksTest.php
@@ -7,7 +7,7 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * @see http://delicious.com/
  */
-class ParseDeliciousBookmarksTest extends \PHPUnit\Framework\TestCase
+class ParseDeliciousBookmarksTest extends TestCase
 {
     /**
      * Delete log file.

--- a/tests/ParseEmptyFileTest.php
+++ b/tests/ParseEmptyFileTest.php
@@ -5,12 +5,12 @@ namespace Shaarli\NetscapeBookmarkParser;
 /**
  * Ensure that trying to import an empty file is handled properly.
  */
-class ParseEmptyFileTest extends \PHPUnit_Framework_TestCase
+class ParseEmptyFileTest extends TestCase
 {
     /**
      * Delete log file.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/ParseFirefoxBookmarksTest.php
+++ b/tests/ParseFirefoxBookmarksTest.php
@@ -7,12 +7,12 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * The reference data has been dumped with Mozilla Firefox 46.0.1
  */
-class ParseFirefoxBookmarksTest extends \PHPUnit_Framework_TestCase
+class ParseFirefoxBookmarksTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/ParseFirefoxBookmarksTest.php
+++ b/tests/ParseFirefoxBookmarksTest.php
@@ -7,7 +7,7 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * The reference data has been dumped with Mozilla Firefox 46.0.1
  */
-class ParseFirefoxBookmarksTest extends \PHPUnit\Framework\TestCase
+class ParseFirefoxBookmarksTest extends TestCase
 {
     /**
      * Delete log file.

--- a/tests/ParseGoogleBookmarksTest.php
+++ b/tests/ParseGoogleBookmarksTest.php
@@ -7,7 +7,7 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * The reference data has been dumped with Google Bookmarks on 2018-10-01
  */
-class ParseGoogleBookmarksTest extends \PHPUnit\Framework\TestCase
+class ParseGoogleBookmarksTest extends TestCase
 {
     /**
      * Delete log file.

--- a/tests/ParseGoogleBookmarksTest.php
+++ b/tests/ParseGoogleBookmarksTest.php
@@ -7,12 +7,12 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * The reference data has been dumped with Google Bookmarks on 2018-10-01
  */
-class ParseGoogleBookmarksTest extends \PHPUnit_Framework_TestCase
+class ParseGoogleBookmarksTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/ParseInternetExplorerBookmarksTest.php
+++ b/tests/ParseInternetExplorerBookmarksTest.php
@@ -7,7 +7,7 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * The reference data has been dumped with IE 11
  */
-class ParseInternetExplorerBookmarksTest extends \PHPUnit\Framework\TestCase
+class ParseInternetExplorerBookmarksTest extends TestCase
 {
     protected $parser = null;
 

--- a/tests/ParseInternetExplorerBookmarksTest.php
+++ b/tests/ParseInternetExplorerBookmarksTest.php
@@ -7,14 +7,14 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * The reference data has been dumped with IE 11
  */
-class ParseInternetExplorerBookmarksTest extends \PHPUnit_Framework_TestCase
+class ParseInternetExplorerBookmarksTest extends \PHPUnit\Framework\TestCase
 {
     protected $parser = null;
 
     /**
      * Initialize test resources
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = new NetscapeBookmarkParser(true, array(), 'error');
     }
@@ -22,7 +22,7 @@ class ParseInternetExplorerBookmarksTest extends \PHPUnit_Framework_TestCase
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/ParseNetscapeBookmarksTest.php
+++ b/tests/ParseNetscapeBookmarksTest.php
@@ -8,14 +8,14 @@ namespace Shaarli\NetscapeBookmarkParser;
  * @see https://msdn.microsoft.com/en-us/library/aa753582%28v=vs.85%29.aspx
  * @see http://www.w3schools.com/tags/tag_dl.asp
  */
-class ParseNetscapeBookmarksTest extends \PHPUnit_Framework_TestCase
+class ParseNetscapeBookmarksTest extends \PHPUnit\Framework\TestCase
 {
     protected $parser = null;
 
     /**
      * Initialize test resources
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = new NetscapeBookmarkParser(true, array(), 'error');
     }
@@ -23,7 +23,7 @@ class ParseNetscapeBookmarksTest extends \PHPUnit_Framework_TestCase
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/ParseNetscapeBookmarksTest.php
+++ b/tests/ParseNetscapeBookmarksTest.php
@@ -8,7 +8,7 @@ namespace Shaarli\NetscapeBookmarkParser;
  * @see https://msdn.microsoft.com/en-us/library/aa753582%28v=vs.85%29.aspx
  * @see http://www.w3schools.com/tags/tag_dl.asp
  */
-class ParseNetscapeBookmarksTest extends \PHPUnit\Framework\TestCase
+class ParseNetscapeBookmarksTest extends TestCase
 {
     protected $parser = null;
 

--- a/tests/ParseSafariBookmarksTest.php
+++ b/tests/ParseSafariBookmarksTest.php
@@ -5,12 +5,12 @@ namespace Shaarli\NetscapeBookmarkParser;
 /**
  * Ensure Safari exports are properly parsed
  */
-class ParseSafariBookmarksTest extends \PHPUnit_Framework_TestCase
+class ParseSafariBookmarksTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/ParseSafariBookmarksTest.php
+++ b/tests/ParseSafariBookmarksTest.php
@@ -5,7 +5,7 @@ namespace Shaarli\NetscapeBookmarkParser;
 /**
  * Ensure Safari exports are properly parsed
  */
-class ParseSafariBookmarksTest extends \PHPUnit\Framework\TestCase
+class ParseSafariBookmarksTest extends TestCase
 {
     /**
      * Delete log file.

--- a/tests/ParseScuttleBookmarksTest.php
+++ b/tests/ParseScuttleBookmarksTest.php
@@ -7,12 +7,12 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * @see https://sourceforge.net/projects/scuttle/
  */
-class ParseScuttleBookmarksTest extends \PHPUnit_Framework_TestCase
+class ParseScuttleBookmarksTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/ParseScuttleBookmarksTest.php
+++ b/tests/ParseScuttleBookmarksTest.php
@@ -7,7 +7,7 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * @see https://sourceforge.net/projects/scuttle/
  */
-class ParseScuttleBookmarksTest extends \PHPUnit\Framework\TestCase
+class ParseScuttleBookmarksTest extends TestCase
 {
     /**
      * Delete log file.

--- a/tests/ParseShaarliBookmarksTest.php
+++ b/tests/ParseShaarliBookmarksTest.php
@@ -7,7 +7,7 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * @see https://github.com/shaarli/Shaarli
  */
-class ParseShaarliBookmarksTest extends \PHPUnit\Framework\TestCase
+class ParseShaarliBookmarksTest extends TestCase
 {
     protected $parser = null;
 

--- a/tests/ParseShaarliBookmarksTest.php
+++ b/tests/ParseShaarliBookmarksTest.php
@@ -7,14 +7,14 @@ namespace Shaarli\NetscapeBookmarkParser;
  *
  * @see https://github.com/shaarli/Shaarli
  */
-class ParseShaarliBookmarksTest extends \PHPUnit_Framework_TestCase
+class ParseShaarliBookmarksTest extends \PHPUnit\Framework\TestCase
 {
     protected $parser = null;
 
     /**
      * Initialize test resources
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parser = new NetscapeBookmarkParser();
     }
@@ -22,7 +22,7 @@ class ParseShaarliBookmarksTest extends \PHPUnit_Framework_TestCase
     /**
      * Delete log file.
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/ParseShaarliWithTabsAndSpacesTest.php
+++ b/tests/ParseShaarliWithTabsAndSpacesTest.php
@@ -2,12 +2,12 @@
 
 namespace Shaarli\NetscapeBookmarkParser;
 
-class ParseShaarliWithTabsAndSpacesTest extends \PHPUnit_Framework_TestCase
+class ParseShaarliWithTabsAndSpacesTest extends TestCase
 {
     /**
      * Delete log file.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shaarli\NetscapeBookmarkParser;
+
+/**
+ * Helper class extending \PHPUnit\Framework\TestCase.
+ * Used to make Shaarli UT run on multiple versions of PHPUnit.
+ */
+class TestCase extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * assertContains is now used for iterable, strings should use assertStringContainsString
+     */
+    public function assertContainsPolyfill($expected, $actual, string $message = ''): void
+    {
+        if (is_string($actual) && method_exists($this, 'assertStringContainsString')) {
+            static::assertStringContainsString($expected, $actual, $message);
+        } else {
+            static::assertContains($expected, $actual, $message);
+        }
+    }
+
+    /**
+     * assertNotContains is now used for iterable, strings should use assertStringNotContainsString
+     */
+    public function assertNotContainsPolyfill($expected, $actual, string $message = ''): void
+    {
+        if (is_string($actual) && method_exists($this, 'assertStringNotContainsString')) {
+            static::assertStringNotContainsString($expected, $actual, $message);
+        } else {
+            static::assertNotContains($expected, $actual, $message);
+        }
+    }
+}


### PR DESCRIPTION
  - Add CI support for for PHP 7.3 - 8.0
  - Include PHPUnit 8.x and 9.x as dependencies
  - Add Shaarli's TestCase polyfill class for assertContains and
assertNotContains

Closes #47

