### PR TITLE
Enforce PSR-12 rules with PHPCS linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ install:
   - composer self-update
   - composer install --prefer-dist
 script:
+  - make lint
   - make test

--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,7 @@ BIN = vendor/bin
 
 test:
 	@$(BIN)/phpunit tests
+lint:
+	@$(BIN)/phpcs
+lint-fix:
+	@$(BIN)/phpcbf

--- a/NetscapeBookmarkParser.php
+++ b/NetscapeBookmarkParser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shaarli\NetscapeBookmarkParser;
 
 use Psr\Log\LoggerAwareInterface;
@@ -24,34 +26,34 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
      */
     protected $logger;
 
-    const TRUE_PATTERN = 'y|yes|on|checked|ok|1|true|array|\+|okay|yes|t|one';
-    const FALSE_PATTERN = 'n|no|off|empty|null|false|nil|0|-|exit|die|neg|f|zero|void';
+    protected const TRUE_PATTERN = 'y|yes|on|checked|ok|1|true|array|\+|okay|yes|t|one';
+    protected const FALSE_PATTERN = 'n|no|off|empty|null|false|nil|0|-|exit|die|neg|f|zero|void';
 
     /**
      * Instantiates a new NetscapeBookmarkParser
      *
-     * @param bool   $keepNestedTags Tag links with parent folder names
-     * @param array  $defaultTags    Tag all links with these values
-     * @param mixed  $defaultPub     Link publication status if missing
-     *                               - '1' => public
-     *                               - '0' => private)
-     * @param string $logDir         Log directory
-     * @param bool   $normalizeDates Whether parsed dates are expected to fall within
-     *                               a given date/time interval
-     * @param string $dateRange      Delta used to compute the "acceptable" date/time interval
+     * @param bool        $keepNestedTags Tag links with parent folder names
+     * @param array|null  $defaultTags    Tag all links with these values
+     * @param mixed       $defaultPub     Link publication status if missing
+     *                                      - '1' => public
+     *                                      - '0' => private)
+     * @param string|null $logDir         Log directory
+     * @param bool        $normalizeDates Whether parsed dates are expected to fall within
+     *                                    a given date/time interval
+     * @param string      $dateRange      Delta used to compute the "acceptable" date/time interval
      */
     public function __construct(
-        $keepNestedTags = true,
-        $defaultTags = array(),
+        bool $keepNestedTags = true,
+        ?array $defaultTags = [],
         $defaultPub = '0',
-        $logDir = null,
-        $normalizeDates = true,
-        $dateRange = '30 years'
+        string $logDir = null,
+        bool $normalizeDates = true,
+        string $dateRange = '30 years'
     ) {
         if ($keepNestedTags) {
             $this->keepNestedTags = true;
         }
-        if ($defaultTags) {
+        if ($defaultTags !== null) {
             $this->defaultTags = $defaultTags;
         } else {
             $this->defaultTags = [];
@@ -78,7 +80,7 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
      *
      * @return array An associative array containing parsed links
      */
-    public function parseFile($filename)
+    public function parseFile(string $filename): array
     {
         $this->logger->info('Starting to parse ' . $filename);
         return $this->parseString(file_get_contents($filename));
@@ -110,7 +112,7 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
      *
      * @return array An associative array containing parsed links
      */
-    public function parseString($bookmarkString)
+    public function parseString(string $bookmarkString): array
     {
         $i = 0;
         $folderTags = [];
@@ -200,7 +202,9 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
                 } else {
                     $this->items[$i]['pub'] = $this->defaultPub;
                 }
-                $this->logger->debug('[#' . $line_no . '] Visibility: ' . ($this->items[$i]['pub'] ? 'public' : 'private'));
+                $this->logger->debug(
+                    '[#' . $line_no . '] Visibility: ' . ($this->items[$i]['pub'] ? 'public' : 'private')
+                );
 
                 $i++;
             }
@@ -222,7 +226,7 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
      * @return int Unix timestamp corresponding to a successfully parsed date,
      *             else current date and time
      */
-    public function parseDate($date)
+    public function parseDate(string $date): int
     {
         if (strtotime('@' . $date)) {
             // Unix timestamp
@@ -257,9 +261,9 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
      *
      * @param string $epoch     Unix timestamp to normalize
      *
-     * @return string Unix timestamp in seconds, within the expected range
+     * @return int Unix timestamp in seconds, within the expected range
      */
-    public function normalizeDate($epoch)
+    public function normalizeDate(string $epoch): int
     {
         $date = new \DateTime('@' . $epoch);
         $maxDate = new \DateTime('+' . $this->dateRange);
@@ -312,7 +316,7 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
      *
      * @return string Sanitized bookmark string
      */
-    public static function sanitizeString($bookmarkString)
+    public static function sanitizeString(string $bookmarkString): string
     {
         $sanitized = $bookmarkString;
 
@@ -438,7 +442,7 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
      *
      * @param LoggerInterface $logger
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }

--- a/NetscapeBookmarkParser.php
+++ b/NetscapeBookmarkParser.php
@@ -41,14 +41,13 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
      * @param string $dateRange      Delta used to compute the "acceptable" date/time interval
      */
     public function __construct(
-        $keepNestedTags=true,
-        $defaultTags=array(),
-        $defaultPub='0',
-        $logDir=null,
-        $normalizeDates=true,
-        $dateRange='30 years'
-    )
-    {
+        $keepNestedTags = true,
+        $defaultTags = array(),
+        $defaultPub = '0',
+        $logDir = null,
+        $normalizeDates = true,
+        $dateRange = '30 years'
+    ) {
         if ($keepNestedTags) {
             $this->keepNestedTags = true;
         }
@@ -81,7 +80,7 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
      */
     public function parseFile($filename)
     {
-        $this->logger->info('Starting to parse '. $filename);
+        $this->logger->info('Starting to parse ' . $filename);
         return $this->parseString(file_get_contents($filename));
     }
 
@@ -111,7 +110,8 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
      *
      * @return array An associative array containing parsed links
      */
-    public function parseString($bookmarkString) {
+    public function parseString($bookmarkString)
+    {
         $i = 0;
         $folderTags = [];
         $groupedFolderTags = [];
@@ -119,8 +119,8 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
         $lines = explode("\n", $this->sanitizeString($bookmarkString));
 
         foreach ($lines as $line_no => $line) {
-            $this->logger->info('PARSING LINE #'. $line_no);
-            $this->logger->debug('[#' . $line_no . '] Content: '. $line);
+            $this->logger->info('PARSING LINE #' . $line_no);
+            $this->logger->debug('[#' . $line_no . '] Content: ' . $line);
             if (preg_match('/^<h\d.*>(.*)<\/h\d>/i', $line, $m1)) {
                 // a header is matched:
                 // - links may be grouped in a (sub-)folder
@@ -131,7 +131,6 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
                 $folderTags = static::flattenTagsList($groupedFolderTags);
                 $this->logger->debug('[#' . $line_no . '] Header found: ' . implode(' ', $tag));
                 continue;
-
             } elseif (preg_match('/^<\/DL>/i', $line)) {
                 // </DL> matched: stop using header value
                 $tag = array_pop($groupedFolderTags);
@@ -185,14 +184,14 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
                     );
                 }
                 $this->items[$i]['tags'] = $tags;
-                $this->logger->debug('[#' . $line_no . '] Tag list: '. implode(' ', $this->items[$i]['tags']));
+                $this->logger->debug('[#' . $line_no . '] Tag list: ' . implode(' ', $this->items[$i]['tags']));
 
                 if (preg_match('/add_date="(.*?)"/i', $line, $m8)) {
                     $this->items[$i]['time'] = $this->parseDate($m8[1]);
                 } else {
                     $this->items[$i]['time'] = time();
                 }
-                $this->logger->debug('[#' . $line_no . '] Date: '. $this->items[$i]['time']);
+                $this->logger->debug('[#' . $line_no . '] Date: ' . $this->items[$i]['time']);
 
                 if (preg_match('/(public|published|pub)="(.*?)"/i', $line, $m9)) {
                     $this->items[$i]['pub'] = $this->parseBoolean($m9[2], false) ? 1 : 0;
@@ -201,7 +200,7 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
                 } else {
                     $this->items[$i]['pub'] = $this->defaultPub;
                 }
-                $this->logger->debug('[#' . $line_no . '] Visibility: '. ($this->items[$i]['pub'] ? 'public' : 'private'));
+                $this->logger->debug('[#' . $line_no . '] Visibility: ' . ($this->items[$i]['pub'] ? 'public' : 'private'));
 
                 $i++;
             }
@@ -225,13 +224,13 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
      */
     public function parseDate($date)
     {
-        if (strtotime('@'.$date)) {
+        if (strtotime('@' . $date)) {
             // Unix timestamp
             if ($this->normalizeDates) {
                 $date = $this->normalizeDate($date);
             }
-            return strtotime('@'.$date);
-        } else if (strtotime($date)) {
+            return strtotime('@' . $date);
+        } elseif (strtotime($date)) {
             // attempt to parse a known compound date/time format
             return strtotime($date);
         }
@@ -260,13 +259,14 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
      *
      * @return string Unix timestamp in seconds, within the expected range
      */
-    public function normalizeDate($epoch) {
-        $date = new \DateTime('@'.$epoch);
-        $maxDate = new \DateTime('+'.$this->dateRange);
+    public function normalizeDate($epoch)
+    {
+        $date = new \DateTime('@' . $epoch);
+        $maxDate = new \DateTime('+' . $this->dateRange);
 
         for ($i = 1; $date > $maxDate; $i++) {
             // trim the provided date until it falls within the expected range
-            $date = new \DateTime('@'.substr($epoch, 0, strlen($epoch) - $i));
+            $date = new \DateTime('@' . substr($epoch, 0, strlen($epoch) - $i));
         }
 
         return $date->getTimestamp();
@@ -282,7 +282,8 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
      *               'false' when the value is evaluated as false
      *               $this->defaultPub if the value is not a boolean
      */
-    public function parseBoolean($value) {
+    public function parseBoolean($value)
+    {
         if (! $value) {
             return false;
         }
@@ -290,10 +291,10 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
             return true;
         }
 
-        if (preg_match("/^(".self::TRUE_PATTERN.")$/i", $value)) {
+        if (preg_match("/^(" . self::TRUE_PATTERN . ")$/i", $value)) {
             return true;
         }
-        if (preg_match("/^(".self::FALSE_PATTERN.")$/i", $value)) {
+        if (preg_match("/^(" . self::FALSE_PATTERN . ")$/i", $value)) {
             return false;
         }
         return $this->defaultPub;
@@ -334,8 +335,8 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
         // line feeds are converted to <br>
         $sanitized = preg_replace_callback(
             '@<DD>(.*?)(</?(:?DT|DD|DL))@mis',
-            function($match) {
-        		return '<DD>'.str_replace("\n", '<br>', trim($match[1])).PHP_EOL. $match[2];
+            function ($match) {
+                return '<DD>' . str_replace("\n", '<br>', trim($match[1])) . PHP_EOL . $match[2];
             },
             $sanitized
         );
@@ -344,8 +345,8 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
         // line feeds are converted to <br>
         $sanitized = preg_replace_callback(
             '@<A(.*?)</A>@mis',
-            function($match) {
-                return '<A '.str_replace("\n", '<br>', trim($match[1])).'</A>';
+            function ($match) {
+                return '<A ' . str_replace("\n", '<br>', trim($match[1])) . '</A>';
             },
             $sanitized
         );
@@ -406,7 +407,7 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
             $value = preg_replace('/^[[:punct:]]/', '', $value);
 
             // trim all but alphanumeric characters, underscores and non-leading dashes
-            $value = preg_replace('/[^\p{L}\p{N}\-_'. ($keepWhiteSpaces ? ' ' : '') .']++/u', '', $value);
+            $value = preg_replace('/[^\p{L}\p{N}\-_' . ($keepWhiteSpaces ? ' ' : '') . ']++/u', '', $value);
 
             if ($value == '') {
                 unset($tags[$key]);

--- a/NetscapeBookmarkParser.php
+++ b/NetscapeBookmarkParser.php
@@ -63,10 +63,10 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
         $this->setLogger(new Logger(
             $logDir == null ? 'logs/' : $logDir,
             LogLevel::INFO,
-            array(
+            [
                 'prefix' => 'import.',
                 'extension' => 'log',
-            )
+            ]
         ));
 
         $this->normalizeDates = $normalizeDates;
@@ -170,7 +170,7 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
                     $this->logger->debug('[#' . $line_no . '] Empty content');
                 }
 
-                $tags = array();
+                $tags = [];
                 if ($this->defaultTags) {
                     $tags = array_merge($tags, $this->defaultTags);
                 }

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "katzgrau/klogger": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+        "squizlabs/php_codesniffer": "^3.5"
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+
+    <rule ref="PSR12" />
+    <rule ref="Generic.PHP.RequireStrictTypes.MissingDeclaration" />
+
+    <file>NetscapeBookmarkParser.php</file>
+    <file>tests</file>
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,6 +7,7 @@
 
     <rule ref="PSR12" />
     <rule ref="Generic.PHP.RequireStrictTypes.MissingDeclaration" />
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
 
     <file>NetscapeBookmarkParser.php</file>
     <file>tests</file>

--- a/tests/ImportLoggerTest.php
+++ b/tests/ImportLoggerTest.php
@@ -54,14 +54,14 @@ class ImportLoggerTest extends TestCase
      */
     public function testLoggerDebug()
     {
-        $this->parser = new NetscapeBookmarkParser(true, array(), '0');
+        $this->parser = new NetscapeBookmarkParser(true, [], '0');
         $this->parser->setLogger(new Logger(
             'logs',
             LogLevel::DEBUG,
-            array(
+            [
                 'prefix' => 'import.',
                 'extension' => 'log',
-            )
+            ]
         ));
         $this->parser->parseFile('tests/input/shaarli.htm');
         $this->assertFileExists(LoggerTestsUtils::getLogFile());
@@ -76,14 +76,14 @@ class ImportLoggerTest extends TestCase
     public function testLoggerAlternativeDir()
     {
         mkdir('tmp');
-        $this->parser = new NetscapeBookmarkParser(true, array(), '0');
+        $this->parser = new NetscapeBookmarkParser(true, [], '0');
         $this->parser->setLogger(new Logger(
             'tmp',
             LogLevel::INFO,
-            array(
+            [
                 'prefix' => 'import.',
                 'extension' => 'log',
-            )
+            ]
         ));
         $this->parser->parseFile('tests/input/shaarli.htm');
         $this->assertFileExists(LoggerTestsUtils::getLogFile('tmp'));

--- a/tests/ImportLoggerTest.php
+++ b/tests/ImportLoggerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shaarli\NetscapeBookmarkParser;
 
 use Katzgrau\KLogger\Logger;
@@ -31,7 +33,7 @@ class ImportLoggerTest extends TestCase
     protected function tearDown(): void
     {
         @unlink(LoggerTestsUtils::getLogFile());
-        @unlink(LoggerTestsUtils::getLogFile('tmp'));
+        @unlink(LoggerTestsUtils::getLogFile('tmp') ?? '');
         @rmdir('tmp');
     }
 

--- a/tests/LoggerTestsUtils.php
+++ b/tests/LoggerTestsUtils.php
@@ -18,6 +18,6 @@ class LoggerTestsUtils
     public static function getLogFile($directory = 'logs')
     {
         $logs = glob($directory . '/import*.log');
-        return ! empty ($logs) ? $logs[0] : false;
+        return ! empty($logs) ? $logs[0] : false;
     }
 }

--- a/tests/LoggerTestsUtils.php
+++ b/tests/LoggerTestsUtils.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shaarli\NetscapeBookmarkParser;
 
 /**
@@ -12,12 +14,13 @@ class LoggerTestsUtils
     /**
      * Retrieve the
      *
-     * @param string $directory
-     * @return bool
+     * @param string|null $directory
+     *
+     * @return string|null
      */
-    public static function getLogFile($directory = 'logs')
+    public static function getLogFile(?string $directory = 'logs'): ?string
     {
         $logs = glob($directory . '/import*.log');
-        return ! empty($logs) ? $logs[0] : false;
+        return ! empty($logs) ? $logs[0] : null;
     }
 }

--- a/tests/ParseChromiumBookmarksTest.php
+++ b/tests/ParseChromiumBookmarksTest.php
@@ -73,13 +73,13 @@ class ParseChromiumBookmarksTest extends TestCase
         $this->assertEquals('1466009639', $bkm[5]['time']);
         $this->assertEquals(
             'Are there any worse sorting algorithms than Bogosort'
-           .' (a.k.a Monkey Sort)? - Stack Overflow',
+            . ' (a.k.a Monkey Sort)? - Stack Overflow',
             $bkm[5]['title']
         );
         $this->assertEquals(
             'http://stackoverflow.com/questions/2609857/'
-           .'are-there-any-worse-sorting-algorithms-than-bogosort'
-           .'-a-k-a-monkey-sort',
+            . 'are-there-any-worse-sorting-algorithms-than-bogosort'
+            . '-a-k-a-monkey-sort',
             $bkm[5]['uri']
         );
 
@@ -89,7 +89,7 @@ class ParseChromiumBookmarksTest extends TestCase
         $this->assertEquals('1466009667', $bkm[6]['time']);
         $this->assertEquals(
             'GitHub - lhartikk/ArnoldC: Arnold Schwarzenegger based'
-           .' programming language',
+            . ' programming language',
             $bkm[6]['title']
         );
         $this->assertEquals(
@@ -117,7 +117,7 @@ class ParseChromiumBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'http://lotrproject.com/blog/2013/02/08/'
-           .'timeline-of-the-elves-in-tolkiens-works/',
+            . 'timeline-of-the-elves-in-tolkiens-works/',
             $bkm[8]['uri']
         );
     }
@@ -165,7 +165,7 @@ class ParseChromiumBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'http://lotrproject.com/blog/2013/02/08/timeline-of-the-elves'
-           .'-in-tolkiens-works/',
+            . '-in-tolkiens-works/',
             $bkm[3]['uri']
         );
 
@@ -185,13 +185,13 @@ class ParseChromiumBookmarksTest extends TestCase
         $this->assertEquals('1466013093', $bkm[5]['time']);
         $this->assertEquals(
             'php - Best practices to test protected methods with PHPUnit'
-           .' - Stack Overflow',
+            . ' - Stack Overflow',
             $bkm[5]['title']
         );
         $this->assertEquals(
             'http://stackoverflow.com/questions/249664/'
-           .'best-practices-to-test-protected-methods-with-phpunit/'
-           .'2798203#2798203',
+            . 'best-practices-to-test-protected-methods-with-phpunit/'
+            . '2798203#2798203',
             $bkm[5]['uri']
         );
 
@@ -234,7 +234,7 @@ class ParseChromiumBookmarksTest extends TestCase
         $this->assertEquals('1466011676', $bkm[9]['time']);
         $this->assertEquals(
             'GitHub - lhartikk/ArnoldC: Arnold Schwarzenegger based'
-           .' programming language',
+            . ' programming language',
             $bkm[9]['title']
         );
         $this->assertEquals(
@@ -248,13 +248,13 @@ class ParseChromiumBookmarksTest extends TestCase
         $this->assertEquals('1466011763', $bkm[10]['time']);
         $this->assertEquals(
             'Are there any worse sorting algorithms than Bogosort'
-           .' (a.k.a Monkey Sort)? - Stack Overflow',
+            . ' (a.k.a Monkey Sort)? - Stack Overflow',
             $bkm[10]['title']
         );
         $this->assertEquals(
             'http://stackoverflow.com/questions/2609857/'
-           .'are-there-any-worse-sorting-algorithms-than-bogosort'
-           .'-a-k-a-monkey-sort',
+            . 'are-there-any-worse-sorting-algorithms-than-bogosort'
+            . '-a-k-a-monkey-sort',
             $bkm[10]['uri']
         );
 
@@ -308,8 +308,8 @@ class ParseChromiumBookmarksTest extends TestCase
         $this->assertEquals('1466012934', $bkm[16]['time']);
         $this->assertEquals(
             'GitHub - shaarli/Shaarli:'
-           .' The personal, minimalist, super-fast, database free,'
-           .' bookmarking service - community repo',
+            . ' The personal, minimalist, super-fast, database free,'
+            . ' bookmarking service - community repo',
             $bkm[16]['title']
         );
         $this->assertEquals(

--- a/tests/ParseChromiumBookmarksTest.php
+++ b/tests/ParseChromiumBookmarksTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shaarli\NetscapeBookmarkParser;
 
 /**

--- a/tests/ParseDeliciousBookmarksTest.php
+++ b/tests/ParseDeliciousBookmarksTest.php
@@ -28,7 +28,7 @@ class ParseDeliciousBookmarksTest extends TestCase
 
         $this->assertEquals(
             'Export your bookmarks to an HTML file, which can be used as a'
-           .' backup or for importing into another web browser',
+            . ' backup or for importing into another web browser',
             $bkm[0]['note']
         );
         $this->assertEquals('1', $bkm[0]['pub']);
@@ -48,7 +48,7 @@ class ParseDeliciousBookmarksTest extends TestCase
         $this->assertEquals('1428876000', $bkm[3]['time']);
         $this->assertEquals(
             'http://storml.deviantart.com/art/Mine-Turtle-Instructions-'
-           .'302477240?q=in%3Ascraps%20sort%3Atime%20gallery%3Astorml&qo=1',
+            . '302477240?q=in%3Ascraps%20sort%3Atime%20gallery%3Astorml&qo=1',
             $bkm[3]['uri']
         );
 
@@ -94,7 +94,7 @@ class ParseDeliciousBookmarksTest extends TestCase
         $this->assertEquals('Changer le monde - Carnets Web de La Grange', $bkm[1]['title']);
         $this->assertEquals(
             'La juxtaposition des mots propriétés et intellectuel (du monde des idées) '
-           .'est une aberration dans un contexte de l\'échange et de la culture.',
+            . 'est une aberration dans un contexte de l\'échange et de la culture.',
             $bkm[1]['note']
         );
     }

--- a/tests/ParseDeliciousBookmarksTest.php
+++ b/tests/ParseDeliciousBookmarksTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shaarli\NetscapeBookmarkParser;
 
 /**

--- a/tests/ParseEmptyFileTest.php
+++ b/tests/ParseEmptyFileTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shaarli\NetscapeBookmarkParser;
 
 /**

--- a/tests/ParseFirefoxBookmarksTest.php
+++ b/tests/ParseFirefoxBookmarksTest.php
@@ -39,7 +39,7 @@ class ParseFirefoxBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'place:folder=BOOKMARKS_MENU&folder=UNFILED_BOOKMARKS&folder=TOOLBAR'
-           .'&queryType=1&sort=12&maxResults=10&excludeQueries=1',
+            . '&queryType=1&sort=12&maxResults=10&excludeQueries=1',
             $bkm[0]['uri']
         );
 
@@ -61,7 +61,7 @@ class ParseFirefoxBookmarksTest extends TestCase
 
         $this->assertEquals(
             'netscape-bookmark-parser - a php script (function) to parse netscape'
-           .' format bookmark files',
+            . ' format bookmark files',
             $bkm[2]['note']
         );
         $this->assertEquals(
@@ -78,7 +78,7 @@ class ParseFirefoxBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'kafene/netscape-bookmark-parser: a php script (function) to parse'
-           .' netscape format bookmark files',
+            . ' netscape format bookmark files',
             $bkm[2]['title']
         );
         $this->assertEquals(
@@ -117,7 +117,7 @@ class ParseFirefoxBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'Survive The Deep End: PHP Security — Survive The Deep End:'
-           .' PHP Security :: v1.0a1',
+            . ' PHP Security :: v1.0a1',
             $bkm[4]['title']
         );
         $this->assertEquals(
@@ -152,8 +152,8 @@ class ParseFirefoxBookmarksTest extends TestCase
 
         $this->assertEquals(
             'If running a Meetup feels like a full-time job, you&#39;re probably'
-           .' doing it wrong. Volunteering is important and you can make it work'
-           .' with some smart maneuvering.',
+            . ' doing it wrong. Volunteering is important and you can make it work'
+            . ' with some smart maneuvering.',
             $bkm[6]['note']
         );
         $this->assertEquals(
@@ -179,7 +179,7 @@ class ParseFirefoxBookmarksTest extends TestCase
 
         $this->assertEquals(
             'Let’s play a game. I’ll show you a picture and a couple videos'
-           .'—just watch the first five seconds or so—and you figure out&amp;#8230;',
+            . '—just watch the first five seconds or so—and you figure out&amp;#8230;',
             $bkm[7]['note']
         );
         $this->assertEquals(
@@ -196,12 +196,12 @@ class ParseFirefoxBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'The Most Important Object In Computer Graphics History Is This Teapot'
-           .' - Facts So Romantic - Nautilus',
+            . ' - Facts So Romantic - Nautilus',
             $bkm[7]['title']
         );
         $this->assertEquals(
             'http://nautil.us/blog/the-most-important-object-in-computer-graphics'
-           .'-history-is-this-teapot',
+            . '-history-is-this-teapot',
             $bkm[7]['uri']
         );
 
@@ -277,7 +277,7 @@ class ParseFirefoxBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'http://blog.deadpansincerity.com/2011/05/announcing-pony-mode-a-django'
-            .'-editing-mode-for-emacs/',
+            . '-editing-mode-for-emacs/',
             $bkm[10]['uri']
         );
 
@@ -378,7 +378,7 @@ class ParseFirefoxBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'http://gaming.stackexchange.com/questions/21261/is-it-dangerous-to-go-extreme'
-           .'-pig-riding-in-a-thunderstorm',
+            . '-pig-riding-in-a-thunderstorm',
             $bkm[14]['uri']
         );
 
@@ -450,14 +450,14 @@ class ParseFirefoxBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'Chocolate Consumption, Cognitive Function, and Nobel Laureates'
-           .' - Chocolate consumption cognitive function and nobel laurates'
-           .' (NEJM).pdf',
+            . ' - Chocolate consumption cognitive function and nobel laurates'
+            . ' (NEJM).pdf',
             $bkm[17]['title']
         );
         $this->assertEquals(
             'http://www.biostat.jhsph.edu/courses/bio621/misc/Chocolate%20'
-            .'consumption%20cognitive%20function%20and%20nobel'
-           .'%20laurates%20%28NEJM%29.pdf',
+            . 'consumption%20cognitive%20function%20and%20nobel'
+            . '%20laurates%20%28NEJM%29.pdf',
             $bkm[17]['uri']
         );
 
@@ -513,10 +513,10 @@ class ParseFirefoxBookmarksTest extends TestCase
 
         $this->assertEquals(
             'Opt out of global data surveillance programs like PRISM, XKeyscore'
-           .' and Tempora. Help make mass surveillance of entire populations'
-           .' uneconomical! We all have a right to privacy, which you can exercise'
-           .' today by encrypting your communications and ending your reliance'
-           .' on proprietary services.',
+            . ' and Tempora. Help make mass surveillance of entire populations'
+            . ' uneconomical! We all have a right to privacy, which you can exercise'
+            . ' today by encrypting your communications and ending your reliance'
+            . ' on proprietary services.',
             $bkm[20]['note']
         );
         $this->assertEquals(
@@ -533,7 +533,7 @@ class ParseFirefoxBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'Opt out of global data surveillance programs like PRISM, XKeyscore,'
-           .' and Tempora - PRISM Break - PRISM Break',
+            . ' and Tempora - PRISM Break - PRISM Break',
             $bkm[20]['title']
         );
         $this->assertEquals(
@@ -543,7 +543,7 @@ class ParseFirefoxBookmarksTest extends TestCase
 
         $this->assertEquals(
             'Fractal Flowchart - Spiked Math Comic - A daily math webcomic'
-            .' meant to entertain and humor the geek in you...',
+            . ' meant to entertain and humor the geek in you...',
             $bkm[21]['note']
         );
         $this->assertEquals(
@@ -622,7 +622,7 @@ class ParseFirefoxBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'place:folder=BOOKMARKS_MENU&folder=UNFILED_BOOKMARKS&folder=TOOLBAR'
-           .'&queryType=1&sort=12&maxResults=10&excludeQueries=1',
+            . '&queryType=1&sort=12&maxResults=10&excludeQueries=1',
             $bkm[0]['uri']
         );
 
@@ -744,7 +744,7 @@ class ParseFirefoxBookmarksTest extends TestCase
 
         $this->assertEquals(
             'Fractal Flowchart - Spiked Math Comic - A daily math webcomic'
-            .' meant to entertain and humor the geek in you...',
+            . ' meant to entertain and humor the geek in you...',
             $bkm[6]['note']
         );
         $this->assertEquals(
@@ -789,7 +789,7 @@ class ParseFirefoxBookmarksTest extends TestCase
 
         $this->assertEquals(
             'Let’s play a game. I’ll show you a picture and a couple videos'
-           .'—just watch the first five seconds or so—and you figure out&amp;#8230;',
+            . '—just watch the first five seconds or so—and you figure out&amp;#8230;',
             $bkm[8]['note']
         );
         $this->assertEquals(
@@ -806,12 +806,12 @@ class ParseFirefoxBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'The Most Important Object In Computer Graphics History Is This Teapot'
-           .' - Facts So Romantic - Nautilus',
+            . ' - Facts So Romantic - Nautilus',
             $bkm[8]['title']
         );
         $this->assertEquals(
             'http://nautil.us/blog/the-most-important-object-in-computer-graphics'
-           .'-history-is-this-teapot',
+            . '-history-is-this-teapot',
             $bkm[8]['uri']
         );
 
@@ -862,7 +862,7 @@ class ParseFirefoxBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'http://blog.deadpansincerity.com/2011/05/announcing-pony-mode-a-django'
-            .'-editing-mode-for-emacs/',
+            . '-editing-mode-for-emacs/',
             $bkm[10]['uri']
         );
 
@@ -918,7 +918,7 @@ class ParseFirefoxBookmarksTest extends TestCase
 
         $this->assertEquals(
             'netscape-bookmark-parser - a php script (function) to parse netscape'
-           .' format bookmark files',
+            . ' format bookmark files',
             $bkm[13]['note']
         );
         $this->assertEquals(
@@ -935,7 +935,7 @@ class ParseFirefoxBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'kafene/netscape-bookmark-parser: a php script (function) to parse'
-           .' netscape format bookmark files',
+            . ' netscape format bookmark files',
             $bkm[13]['title']
         );
         $this->assertEquals(
@@ -955,7 +955,7 @@ class ParseFirefoxBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'Survive The Deep End: PHP Security — Survive The Deep End:'
-           .' PHP Security :: v1.0a1',
+            . ' PHP Security :: v1.0a1',
             $bkm[14]['title']
         );
         $this->assertEquals(
@@ -981,21 +981,21 @@ class ParseFirefoxBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'Chocolate Consumption, Cognitive Function, and Nobel Laureates'
-           .' - Chocolate consumption cognitive function and nobel laurates'
-           .' (NEJM).pdf',
+            . ' - Chocolate consumption cognitive function and nobel laurates'
+            . ' (NEJM).pdf',
             $bkm[15]['title']
         );
         $this->assertEquals(
             'http://www.biostat.jhsph.edu/courses/bio621/misc/Chocolate%20'
-            .'consumption%20cognitive%20function%20and%20nobel'
-           .'%20laurates%20%28NEJM%29.pdf',
+            . 'consumption%20cognitive%20function%20and%20nobel'
+            . '%20laurates%20%28NEJM%29.pdf',
             $bkm[15]['uri']
         );
 
         $this->assertEquals(
             'If running a Meetup feels like a full-time job, you&#39;re probably'
-           .' doing it wrong. Volunteering is important and you can make it work'
-           .' with some smart maneuvering.',
+            . ' doing it wrong. Volunteering is important and you can make it work'
+            . ' with some smart maneuvering.',
             $bkm[16]['note']
         );
         $this->assertEquals(
@@ -1096,10 +1096,10 @@ class ParseFirefoxBookmarksTest extends TestCase
 
         $this->assertEquals(
             'Opt out of global data surveillance programs like PRISM, XKeyscore'
-           .' and Tempora. Help make mass surveillance of entire populations'
-           .' uneconomical! We all have a right to privacy, which you can exercise'
-           .' today by encrypting your communications and ending your reliance'
-           .' on proprietary services.',
+            . ' and Tempora. Help make mass surveillance of entire populations'
+            . ' uneconomical! We all have a right to privacy, which you can exercise'
+            . ' today by encrypting your communications and ending your reliance'
+            . ' on proprietary services.',
             $bkm[20]['note']
         );
         $this->assertEquals(
@@ -1116,7 +1116,7 @@ class ParseFirefoxBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'Opt out of global data surveillance programs like PRISM, XKeyscore,'
-           .' and Tempora - PRISM Break - PRISM Break',
+            . ' and Tempora - PRISM Break - PRISM Break',
             $bkm[20]['title']
         );
         $this->assertEquals(
@@ -1146,7 +1146,7 @@ class ParseFirefoxBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'http://gaming.stackexchange.com/questions/21261/is-it-dangerous-to-go-extreme'
-           .'-pig-riding-in-a-thunderstorm',
+            . '-pig-riding-in-a-thunderstorm',
             $bkm[21]['uri']
         );
 

--- a/tests/ParseFirefoxBookmarksTest.php
+++ b/tests/ParseFirefoxBookmarksTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shaarli\NetscapeBookmarkParser;
 
 /**

--- a/tests/ParseGoogleBookmarksTest.php
+++ b/tests/ParseGoogleBookmarksTest.php
@@ -46,7 +46,7 @@ class ParseGoogleBookmarksTest extends TestCase
         );
         $this->assertequals(
             'https://stackoverflow.com/questions/20180072/'
-            .'move-files-into-alphabetically-named-folders',
+            . 'move-files-into-alphabetically-named-folders',
             $bkm[1]['uri']
         );
 

--- a/tests/ParseGoogleBookmarksTest.php
+++ b/tests/ParseGoogleBookmarksTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shaarli\NetscapeBookmarkParser;
 
 /**

--- a/tests/ParseInternetExplorerBookmarksTest.php
+++ b/tests/ParseInternetExplorerBookmarksTest.php
@@ -83,7 +83,7 @@ class ParseInternetExplorerBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'https://help.github.com/articles/dealing-with-line-endings/'
-           .'#platform-all',
+            . '#platform-all',
             $bkm[3]['uri']
         );
 
@@ -113,7 +113,7 @@ class ParseInternetExplorerBookmarksTest extends TestCase
         $this->assertEquals('1466266989', $bkm[6]['time']);
         $this->assertEquals(
             'Fifty Shades of Grey text generator  '
-           .'Parody erotic fiction generated algorithmically.',
+            . 'Parody erotic fiction generated algorithmically.',
             $bkm[6]['title']
         );
         $this->assertEquals('http://www.xwray.com/fiftyshades', $bkm[6]['uri']);
@@ -124,8 +124,8 @@ class ParseInternetExplorerBookmarksTest extends TestCase
         $this->assertEquals('1466267009', $bkm[7]['time']);
         $this->assertEquals(
             'GitHub - originell-django-kittenstorage '
-           .'Django Storage Engine which returns images of kittens '
-           .'if files could not be found.',
+            . 'Django Storage Engine which returns images of kittens '
+            . 'if files could not be found.',
             $bkm[7]['title']
         );
         $this->assertEquals(
@@ -173,7 +173,7 @@ class ParseInternetExplorerBookmarksTest extends TestCase
         $this->assertEquals('It Never works with cats...', $bkm[11]['title']);
         $this->assertEquals(
             'http://lizclimo.tumblr.com/post/132165201759/'
-           .'bonus-comic-for-national-cat-day',
+            . 'bonus-comic-for-national-cat-day',
             $bkm[11]['uri']
         );
 
@@ -187,7 +187,7 @@ class ParseInternetExplorerBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'http://io9.gizmodo.com/learn-to-write-gallifreyan-in-9'
-           .'-simple-steps-506989915',
+            . '-simple-steps-506989915',
             $bkm[12]['uri']
         );
 
@@ -211,7 +211,7 @@ class ParseInternetExplorerBookmarksTest extends TestCase
         $this->assertEquals('1466269520', $bkm[15]['time']);
         $this->assertEquals(
             'TEDxZurich - Jojo Mayer - Exploring the distance between 0 and 1'
-           .' - YouTube',
+            . ' - YouTube',
             $bkm[15]['title']
         );
         $this->assertEquals(
@@ -239,7 +239,7 @@ class ParseInternetExplorerBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'http://jakevdp.github.io/blog/2013/07/10/'
-           .'XKCD-plots-in-matplotlib/',
+            . 'XKCD-plots-in-matplotlib/',
             $bkm[17]['uri']
         );
     }
@@ -265,7 +265,7 @@ class ParseInternetExplorerBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'http://lizclimo.tumblr.com/post/132165201759/'
-           .'bonus-comic-for-national-cat-day',
+            . 'bonus-comic-for-national-cat-day',
             $bkm[0]['uri']
         );
 
@@ -301,8 +301,8 @@ class ParseInternetExplorerBookmarksTest extends TestCase
         $this->assertEquals('1466267009', $bkm[3]['time']);
         $this->assertEquals(
             'GitHub - originell-django-kittenstorage'
-           .' Django Storage Engine which returns images of kittens'
-           .' if files could not be found.',
+            . ' Django Storage Engine which returns images of kittens'
+            . ' if files could not be found.',
             $bkm[3]['title']
         );
         $this->assertEquals(
@@ -320,7 +320,7 @@ class ParseInternetExplorerBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'http://jakevdp.github.io/blog/2013/07/10/'
-           .'XKCD-plots-in-matplotlib/',
+            . 'XKCD-plots-in-matplotlib/',
             $bkm[4]['uri']
         );
 
@@ -347,7 +347,7 @@ class ParseInternetExplorerBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'https://help.github.com/articles/dealing-with-line-endings/'
-           .'#platform-all',
+            . '#platform-all',
             $bkm[6]['uri']
         );
 
@@ -409,7 +409,7 @@ class ParseInternetExplorerBookmarksTest extends TestCase
         $this->assertEquals('1466266989', $bkm[11]['time']);
         $this->assertEquals(
             'Fifty Shades of Grey text generator'
-           .'  Parody erotic fiction generated algorithmically.',
+            . '  Parody erotic fiction generated algorithmically.',
             $bkm[11]['title']
         );
         $this->assertEquals(
@@ -527,7 +527,7 @@ class ParseInternetExplorerBookmarksTest extends TestCase
         $this->assertEquals('1466269520', $bkm[20]['time']);
         $this->assertEquals(
             'TEDxZurich - Jojo Mayer - Exploring the distance between 0 and 1'
-           .' - YouTube',
+            . ' - YouTube',
             $bkm[20]['title']
         );
         $this->assertEquals(
@@ -597,7 +597,7 @@ class ParseInternetExplorerBookmarksTest extends TestCase
         );
         $this->assertEquals(
             'http://io9.gizmodo.com/learn-to-write-gallifreyan-in-9'
-           .'-simple-steps-506989915',
+            . '-simple-steps-506989915',
             $bkm[25]['uri']
         );
 

--- a/tests/ParseInternetExplorerBookmarksTest.php
+++ b/tests/ParseInternetExplorerBookmarksTest.php
@@ -18,7 +18,7 @@ class ParseInternetExplorerBookmarksTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->parser = new NetscapeBookmarkParser(true, array(), 'error');
+        $this->parser = new NetscapeBookmarkParser(true, [], 'error');
     }
 
     /**

--- a/tests/ParseInternetExplorerBookmarksTest.php
+++ b/tests/ParseInternetExplorerBookmarksTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shaarli\NetscapeBookmarkParser;
 
 /**

--- a/tests/ParseNetscapeBookmarksTest.php
+++ b/tests/ParseNetscapeBookmarksTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shaarli\NetscapeBookmarkParser;
 
 /**
@@ -134,7 +136,7 @@ class ParseNetscapeBookmarksTest extends TestCase
     /**
      * Parse boolean attribute values - evaluating to TRUE
      */
-    function testParseBooleanAttributesTrue()
+    public function testParseBooleanAttributesTrue()
     {
         // standard booleans
         $this->assertTrue($this->parser->parseBoolean('on'));
@@ -162,7 +164,7 @@ class ParseNetscapeBookmarksTest extends TestCase
     /**
      * Parse boolean attribute values - evaluating to FALSE
      */
-    function testParseBooleanAttributesFalse()
+    public function testParseBooleanAttributesFalse()
     {
         // standard booleans
         $this->assertFalse($this->parser->parseBoolean('f'));
@@ -191,7 +193,7 @@ class ParseNetscapeBookmarksTest extends TestCase
     /**
      * Parse boolean attribute values - fail and return the default value
      */
-    function testParseBooleanAttributesDefault()
+    public function testParseBooleanAttributesDefault()
     {
         $default = 'def';
         $parser = new NetscapeBookmarkParser(false, array(), $default);

--- a/tests/ParseNetscapeBookmarksTest.php
+++ b/tests/ParseNetscapeBookmarksTest.php
@@ -63,23 +63,23 @@ class ParseNetscapeBookmarksTest extends TestCase
 
         // simple list
         $this->assertEquals(
-            'List:'.PHP_EOL.'- item1'.PHP_EOL.'- item2'.PHP_EOL.'- item3',
+            'List:' . PHP_EOL . '- item1' . PHP_EOL . '- item2' . PHP_EOL . '- item3',
             $bkm[0]['note']
         );
 
         // nested lists
         $this->assertEquals(
             'Nested lists:'
-           .PHP_EOL.'- list1'.PHP_EOL.'  - item1.1'.PHP_EOL.'  - item1.2'.PHP_EOL.'  - item1.3'
-           .PHP_EOL.'- list2'.PHP_EOL.'  - item2.1',
+            . PHP_EOL . '- list1' . PHP_EOL . '  - item1.1' . PHP_EOL . '  - item1.2' . PHP_EOL . '  - item1.3'
+            . PHP_EOL . '- list2' . PHP_EOL . '  - item2.1',
             $bkm[1]['note']
         );
 
         // list and paragraphs separated by several newlines
         $this->assertEquals(
-            'List:'.PHP_EOL.'- item1'.PHP_EOL.'- item2'.PHP_EOL
-           .PHP_EOL.'Paragraph number one.'.PHP_EOL
-           .PHP_EOL.'Paragraph'.PHP_EOL.'number'.PHP_EOL.'two.',
+            'List:' . PHP_EOL . '- item1' . PHP_EOL . '- item2' . PHP_EOL
+            . PHP_EOL . 'Paragraph number one.' . PHP_EOL
+            . PHP_EOL . 'Paragraph' . PHP_EOL . 'number' . PHP_EOL . 'two.',
             $bkm[2]['note']
         );
     }

--- a/tests/ParseNetscapeBookmarksTest.php
+++ b/tests/ParseNetscapeBookmarksTest.php
@@ -19,7 +19,7 @@ class ParseNetscapeBookmarksTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->parser = new NetscapeBookmarkParser(true, array(), 'error');
+        $this->parser = new NetscapeBookmarkParser(true, [], 'error');
     }
 
     /**
@@ -196,7 +196,7 @@ class ParseNetscapeBookmarksTest extends TestCase
     public function testParseBooleanAttributesDefault()
     {
         $default = 'def';
-        $parser = new NetscapeBookmarkParser(false, array(), $default);
+        $parser = new NetscapeBookmarkParser(false, [], $default);
 
         $this->assertEquals(
             $default,
@@ -400,7 +400,9 @@ class ParseNetscapeBookmarksTest extends TestCase
                        'oceans, escaping repeated attempts of capture. Then a dramatic pursuit ' .
                        'finally netted the one that got away.' . PHP_EOL;
         $description .= '<A href="http://localhost.localdomain:8083/Shaarli/?JVvqCA">' . PHP_EOL;
-        $description .= '<img src="http://localhost.localdomain:8083/Shaarli/cache/thumb/290ccda0deea6083ee613d358446103e/c975558ad43acdbd982ffafd8c01163d6c9ec5ca125901.jpg"/>' . PHP_EOL;
+        $description .= '<img src="http://localhost.localdomain:8083/Shaarli/cache/';
+        $description .= 'thumb/290ccda0deea6083ee613d358446103e/';
+        $description .= 'c975558ad43acdbd982ffafd8c01163d6c9ec5ca125901.jpg"/>' . PHP_EOL;
         $description .= '</A>';
 
         $this->assertEquals(

--- a/tests/ParseSafariBookmarksTest.php
+++ b/tests/ParseSafariBookmarksTest.php
@@ -35,8 +35,8 @@ class ParseSafariBookmarksTest extends TestCase
         $this->assertEquals(['github', 'shaarli'], $bkm[1]['tags']);
         $this->assertEquals(
             'GitHub - shaarli/Shaarli:'
-           .' The personal, minimalist, super-fast, database free,'
-           .' bookmarking service - community repo',
+            . ' The personal, minimalist, super-fast, database free,'
+            . ' bookmarking service - community repo',
             $bkm[1]['title']
         );
         $this->assertEquals('https://github.com/shaarli/Shaarli', $bkm[1]['uri']);

--- a/tests/ParseSafariBookmarksTest.php
+++ b/tests/ParseSafariBookmarksTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shaarli\NetscapeBookmarkParser;
 
 /**

--- a/tests/ParseScuttleBookmarksTest.php
+++ b/tests/ParseScuttleBookmarksTest.php
@@ -51,7 +51,7 @@ class ParseScuttleBookmarksTest extends TestCase
 
         $this->assertEquals(
             '&quot;Durchsuchen Sie Millionen von SÃ¤tzen, die von anderen'
-            .' Menschen Ã¼bersetzt wurden.&quot;',
+            . ' Menschen Ã¼bersetzt wurden.&quot;',
             $bkm[2]['note']
         );
         $this->assertEquals('0', $bkm[2]['pub']);
@@ -68,10 +68,10 @@ class ParseScuttleBookmarksTest extends TestCase
 
         $this->assertEquals(
             "Database of the United Nation's German Translation Section."
-            ." Every record contains at least one German term and a"
-            ." corresponding term usually in English. Most records also"
-            ." contain a French equivalent, some also a Spanish version."
-            ." Not necessarily official.",
+            . " Every record contains at least one German term and a"
+            . " corresponding term usually in English. Most records also"
+            . " contain a French equivalent, some also a Spanish version."
+            . " Not necessarily official.",
             $bkm[3]['note']
         );
         $this->assertEquals('0', $bkm[3]['pub']);
@@ -97,11 +97,11 @@ class ParseScuttleBookmarksTest extends TestCase
         $this->assertEquals(1, sizeof($bkm));
 
         $this->assertEquals(
-             'The best in funk, soul, jazz and rare groove vinyl'. '<br>'
-            .'I have been writing about music in various forms (zines, newspapers, e-zines, blogs) since the mid-80’s. '
-            .'The Funky16Corners blog started in November of 2004 to focus on funk and soul vinyl. '
-            .'Since mid-2006, in addition to individual MP3 tracks, I have been posting mixes '
-            .'under the title Funky16Corners radio. Most MP3s and mixes will be available for a few weeks.',
+            'The best in funk, soul, jazz and rare groove vinyl' . '<br>'
+            . 'I have been writing about music in various forms (zines, newspapers, e-zines, blogs) since the mid-80’s. '
+            . 'The Funky16Corners blog started in November of 2004 to focus on funk and soul vinyl. '
+            . 'Since mid-2006, in addition to individual MP3 tracks, I have been posting mixes '
+            . 'under the title Funky16Corners radio. Most MP3s and mixes will be available for a few weeks.',
             $bkm[0]['note']
         );
         $this->assertEquals('0', $bkm[0]['pub']);

--- a/tests/ParseScuttleBookmarksTest.php
+++ b/tests/ParseScuttleBookmarksTest.php
@@ -99,8 +99,9 @@ class ParseScuttleBookmarksTest extends TestCase
         $this->assertEquals(1, sizeof($bkm));
 
         $this->assertEquals(
-            'The best in funk, soul, jazz and rare groove vinyl' . '<br>'
-            . 'I have been writing about music in various forms (zines, newspapers, e-zines, blogs) since the mid-80’s. '
+            'The best in funk, soul, jazz and rare groove vinyl<br>'
+            . 'I have been writing about music in various forms (zines, newspapers, e-zines, blogs) '
+            . 'since the mid-80’s. '
             . 'The Funky16Corners blog started in November of 2004 to focus on funk and soul vinyl. '
             . 'Since mid-2006, in addition to individual MP3 tracks, I have been posting mixes '
             . 'under the title Funky16Corners radio. Most MP3s and mixes will be available for a few weeks.',

--- a/tests/ParseScuttleBookmarksTest.php
+++ b/tests/ParseScuttleBookmarksTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shaarli\NetscapeBookmarkParser;
 
 /**

--- a/tests/ParseShaarliBookmarksTest.php
+++ b/tests/ParseShaarliBookmarksTest.php
@@ -45,13 +45,13 @@ class ParseShaarliBookmarksTest extends TestCase
         // Shaarli note (permalink)
         $this->assertEquals(
             "&quot;Is there anything more fabulous than something created"
-           ." through the wonder and miracle of caramelization?&quot;".PHP_EOL
-           .PHP_EOL
-           ."- http://www.davidlebovitz.com/2005/08/long-live-the-k/".PHP_EOL
-           ."- http://www.bonappetit.com/recipe/kouign-amann".PHP_EOL
-           .PHP_EOL
-           ."&quot;It is strictly forbidden to think about diet while"
-           ." you're making a Kouign Amann&quot;",
+            . " through the wonder and miracle of caramelization?&quot;" . PHP_EOL
+            . PHP_EOL
+            . "- http://www.davidlebovitz.com/2005/08/long-live-the-k/" . PHP_EOL
+            . "- http://www.bonappetit.com/recipe/kouign-amann" . PHP_EOL
+            . PHP_EOL
+            . "&quot;It is strictly forbidden to think about diet while"
+            . " you're making a Kouign Amann&quot;",
             $bkm[0]['note']
         );
         $this->assertEquals(
@@ -69,7 +69,7 @@ class ParseShaarliBookmarksTest extends TestCase
         $this->assertEquals('1459371358', $bkm[1]['time']);
         $this->assertEquals(
             'http://nautil.us/blog/the-most-important-object-'
-           .'in-computer-graphics-history-is-this-teapot',
+            . 'in-computer-graphics-history-is-this-teapot',
             $bkm[1]['uri']
         );
 
@@ -84,19 +84,19 @@ class ParseShaarliBookmarksTest extends TestCase
         $this->assertEquals('1459371140', $bkm[3]['time']);
         $this->assertEquals(
             'http://storml.deviantart.com/art/Mine-Turtle-Instructions-302477240'
-           .'?q=in%3Ascraps%20sort%3Atime%20gallery%3Astorml&amp;qo=1',
+            . '?q=in%3Ascraps%20sort%3Atime%20gallery%3Astorml&amp;qo=1',
             $bkm[3]['uri']
         );
 
         $this->assertEquals(
             'Welcome to Shaarli! This is your first public bookmark.'
-           .' To edit or delete me, you must first login.'.PHP_EOL
-           .PHP_EOL
-           .'To learn how to use Shaarli, consult the link &quot;Help/documentation&quot;'
-           .' at the bottom of this page.'.PHP_EOL
-           .PHP_EOL
-           .'You use the community supported version of the original Shaarli project,'
-           .' by Sebastien Sauvage.',
+            . ' To edit or delete me, you must first login.' . PHP_EOL
+            . PHP_EOL
+            . 'To learn how to use Shaarli, consult the link &quot;Help/documentation&quot;'
+            . ' at the bottom of this page.' . PHP_EOL
+            . PHP_EOL
+            . 'You use the community supported version of the original Shaarli project,'
+            . ' by Sebastien Sauvage.',
             $bkm[4]['note']
         );
         $this->assertEquals('1', $bkm[4]['pub']);
@@ -110,7 +110,7 @@ class ParseShaarliBookmarksTest extends TestCase
         $this->assertEquals('1459370913', $bkm[5]['time']);
         $this->assertEquals(
             'http://sebsauvage.net/paste/?8434b27936c09649#'
-            .'bR7XsXhoTiLcqCpQbmOpBi3rq2zzQUC5hBI7ZT1O3x8=',
+            . 'bR7XsXhoTiLcqCpQbmOpBi3rq2zzQUC5hBI7ZT1O3x8=',
             $bkm[5]['uri']
         );
     }
@@ -125,19 +125,19 @@ class ParseShaarliBookmarksTest extends TestCase
 
         // Markdown code
         $this->assertEquals(
-            'PHP stuff:'.PHP_EOL
-             .PHP_EOL
-             .'    &lt;?php'.PHP_EOL
-             .'    phpinfo();'.PHP_EOL
-             .'    ?&gt;'.PHP_EOL
-             .PHP_EOL
-             .'Python stuff:'.PHP_EOL
-             .PHP_EOL
-             .'    import logging'.PHP_EOL
-             .'    import os'.PHP_EOL
-             .PHP_EOL
-             ."    if __name__ == '__main__':".PHP_EOL
-             .'        logging.info(&quot;Current directory: %s&quot;, os.getcwd())',
+            'PHP stuff:' . PHP_EOL
+             . PHP_EOL
+             . '    &lt;?php' . PHP_EOL
+             . '    phpinfo();' . PHP_EOL
+             . '    ?&gt;' . PHP_EOL
+             . PHP_EOL
+             . 'Python stuff:' . PHP_EOL
+             . PHP_EOL
+             . '    import logging' . PHP_EOL
+             . '    import os' . PHP_EOL
+             . PHP_EOL
+             . "    if __name__ == '__main__':" . PHP_EOL
+             . '        logging.info(&quot;Current directory: %s&quot;, os.getcwd())',
             $bkm[0]['note']
         );
         $this->assertEquals('1', $bkm[0]['pub']);
@@ -146,17 +146,17 @@ class ParseShaarliBookmarksTest extends TestCase
 
         // Markdown lists
         $this->assertEquals(
-            'Standard:'.PHP_EOL
-             .'* item1'.PHP_EOL
-             .'* item2'.PHP_EOL
-             .'* item3'.PHP_EOL
-             .PHP_EOL
-             .'Nested:'.PHP_EOL
-             .'- item1'.PHP_EOL
-             .'    - item1.1'.PHP_EOL
-             .'    - item1.2'.PHP_EOL
-             .'- item2',
-             $bkm[1]['note']
+            'Standard:' . PHP_EOL
+             . '* item1' . PHP_EOL
+             . '* item2' . PHP_EOL
+             . '* item3' . PHP_EOL
+             . PHP_EOL
+             . 'Nested:' . PHP_EOL
+             . '- item1' . PHP_EOL
+             . '    - item1.1' . PHP_EOL
+             . '    - item1.2' . PHP_EOL
+             . '- item2',
+            $bkm[1]['note']
         );
         $this->assertEquals('1', $bkm[1]['pub']);
         $this->assertEquals('1463262338', $bkm[1]['time']);
@@ -164,26 +164,26 @@ class ParseShaarliBookmarksTest extends TestCase
 
         // Markdown headers
         $this->assertEquals(
-            'A First Level Header'.PHP_EOL
-           .'===================='.PHP_EOL
-           .PHP_EOL
-           .'A Second Level Header'.PHP_EOL
-           .'---------------------'.PHP_EOL
-           .PHP_EOL
-           .'Now is the time for all good men to come to'.PHP_EOL
-           .'the aid of their country. This is just a'.PHP_EOL
-           .'regular paragraph.'.PHP_EOL
-           .PHP_EOL
-           .'The quick brown fox jumped over the lazy'.PHP_EOL
-           .'dog\'s back.'.PHP_EOL
-           .PHP_EOL
-           .'### Header 3'.PHP_EOL
-           .PHP_EOL
-           .'&gt; This is a blockquote.'.PHP_EOL
-           .'&gt; '.PHP_EOL
-           .'&gt; This is the second paragraph in the blockquote.'.PHP_EOL
-           .'&gt;'.PHP_EOL
-           .'&gt; ## This is an H2 in a blockquote',
+            'A First Level Header' . PHP_EOL
+            . '====================' . PHP_EOL
+            . PHP_EOL
+            . 'A Second Level Header' . PHP_EOL
+            . '---------------------' . PHP_EOL
+            . PHP_EOL
+            . 'Now is the time for all good men to come to' . PHP_EOL
+            . 'the aid of their country. This is just a' . PHP_EOL
+            . 'regular paragraph.' . PHP_EOL
+            . PHP_EOL
+            . 'The quick brown fox jumped over the lazy' . PHP_EOL
+            . 'dog\'s back.' . PHP_EOL
+            . PHP_EOL
+            . '### Header 3' . PHP_EOL
+            . PHP_EOL
+            . '&gt; This is a blockquote.' . PHP_EOL
+            . '&gt; ' . PHP_EOL
+            . '&gt; This is the second paragraph in the blockquote.' . PHP_EOL
+            . '&gt;' . PHP_EOL
+            . '&gt; ## This is an H2 in a blockquote',
             $bkm[2]['note']
         );
         $this->assertEquals('1', $bkm[2]['pub']);
@@ -213,9 +213,9 @@ class ParseShaarliBookmarksTest extends TestCase
         $this->assertEquals(
             array(
                 'uri' => 'https://www.addedbytes.com/articles/for-beginners/'
-                         .'url-rewriting-for-beginners/',
+                         . 'url-rewriting-for-beginners/',
                 'title' => 'URL Rewriting for Beginners - '
-                           .'Web Development in Brighton - Added Bytes',
+                           . 'Web Development in Brighton - Added Bytes',
                 'note' => '',
                 'tags' => ['apache'],
                 'time' => 1469950052,

--- a/tests/ParseShaarliBookmarksTest.php
+++ b/tests/ParseShaarliBookmarksTest.php
@@ -202,18 +202,18 @@ class ParseShaarliBookmarksTest extends TestCase
         $this->assertEquals(2, sizeof($bkm));
 
         $this->assertEquals(
-            array(
+            [
                 'uri' => 'https://gist.github.com/rodrigomuniz/8408734',
                 'title' => 'A Pen by Rodrigo Muniz.',
                 'note' => 'simple on/off button',
                 'tags' => ['css'],
                 'time' => 1470640652,
                 'pub' => 0
-            ),
+            ],
             $bkm[0]
         );
         $this->assertEquals(
-            array(
+            [
                 'uri' => 'https://www.addedbytes.com/articles/for-beginners/'
                          . 'url-rewriting-for-beginners/',
                 'title' => 'URL Rewriting for Beginners - '
@@ -222,7 +222,7 @@ class ParseShaarliBookmarksTest extends TestCase
                 'tags' => ['apache'],
                 'time' => 1469950052,
                 'pub' => 1
-            ),
+            ],
             $bkm[1]
         );
     }

--- a/tests/ParseShaarliBookmarksTest.php
+++ b/tests/ParseShaarliBookmarksTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shaarli\NetscapeBookmarkParser;
 
 /**

--- a/tests/ParseShaarliWithTabsAndSpacesTest.php
+++ b/tests/ParseShaarliWithTabsAndSpacesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shaarli\NetscapeBookmarkParser;
 
 class ParseShaarliWithTabsAndSpacesTest extends TestCase

--- a/tests/ParseShaarliWithWhitespaceTagsTest.php
+++ b/tests/ParseShaarliWithWhitespaceTagsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shaarli\NetscapeBookmarkParser;
 
 class ParseShaarliWithWhitespaceTagsTest extends TestCase


### PR DESCRIPTION
  - Add PHP Code Sniffer as dev dependency
  - Apply PHP Code Beautifier for linter automatic fixes
  - Fix linter errors and enforce PHP strict types
  - Enforce short syntax arrays + fix remaining linter issues (line length) 