### PR TITLE
 is provided 2 parameters on lines 199 and 201, but the method signat…

### DIFF
--- a/NetscapeBookmarkParser.php
+++ b/NetscapeBookmarkParser.php
@@ -196,9 +196,9 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
                 $this->logger->debug('[#' . $line_no . '] Date: ' . $this->items[$i]['time']);
 
                 if (preg_match('/(public|published|pub)="(.*?)"/i', $line, $m9)) {
-                    $this->items[$i]['pub'] = $this->parseBoolean($m9[2], false) ? 1 : 0;
+                    $this->items[$i]['pub'] = $this->parseBoolean($m9[2]) ? 1 : 0;
                 } elseif (preg_match('/(private|shared)="(.*?)"/i', $line, $m10)) {
-                    $this->items[$i]['pub'] = $this->parseBoolean($m10[2], true) ? 0 : 1;
+                    $this->items[$i]['pub'] = $this->parseBoolean($m10[2]) ? 0 : 1;
                 } else {
                     $this->items[$i]['pub'] = $this->defaultPub;
                 }


### PR DESCRIPTION
`parseBoolean` is provided 2 parameters on lines 199 and 201, but the method signature accepts only 1 parameter.

I removed second parameter, which I suppose use to provide default value for this method.