### PR TITLE
Misc refactoring and performance improvements.

### DIFF
--- a/NetscapeBookmarkParser.php
+++ b/NetscapeBookmarkParser.php
@@ -19,7 +19,6 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
     protected $defaultPub;
     protected $normalizeDates;
     protected $dateRange;
-    protected $items = [];
 
     /**
      * @var LoggerInterface instance.
@@ -118,6 +117,8 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
         $folderTags = [];
         $groupedFolderTags = [];
 
+        $items = [];
+
         $lines = explode("\n", $this->sanitizeString($bookmarkString));
 
         foreach ($lines as $line_no => $line) {
@@ -144,29 +145,29 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
             if (preg_match('/<a/i', $line, $m2)) {
                 $this->logger->debug('[#' . $line_no . '] Link found');
                 if (preg_match('/href="(.*?)"/i', $line, $m3)) {
-                    $this->items[$i]['uri'] = $m3[1];
+                    $items[$i]['uri'] = $m3[1];
                     $this->logger->debug('[#' . $line_no . '] URL found: ' . $m3[1]);
                 } else {
-                    $this->items[$i]['uri'] = '';
+                    $items[$i]['uri'] = '';
                     $this->logger->debug('[#' . $line_no . '] Empty URL');
                 }
 
                 if (preg_match('/<a.*?[^br]>(.*?)<\/a>/i', $line, $m4)) {
-                    $this->items[$i]['title'] = $m4[1];
+                    $items[$i]['title'] = $m4[1];
                     $this->logger->debug('[#' . $line_no . '] Title found: ' . $m4[1]);
                 } else {
-                    $this->items[$i]['title'] = 'untitled';
+                    $items[$i]['title'] = 'untitled';
                     $this->logger->debug('[#' . $line_no . '] Empty title');
                 }
 
                 if (preg_match('/(description|note)="(.*?)"/i', $line, $m5)) {
-                    $this->items[$i]['note'] = $m5[2];
+                    $items[$i]['note'] = $m5[2];
                     $this->logger->debug('[#' . $line_no . '] Content found: ' . substr($m5[2], 0, 50) . '...');
                 } elseif (preg_match('/<dd>(.*?)$/i', $line, $m6)) {
-                    $this->items[$i]['note'] = str_replace('<br>', "\n", $m6[1]);
+                    $items[$i]['note'] = str_replace('<br>', "\n", $m6[1]);
                     $this->logger->debug('[#' . $line_no . '] Content found: ' . substr($m6[1], 0, 50) . '...');
                 } else {
-                    $this->items[$i]['note'] = '';
+                    $items[$i]['note'] = '';
                     $this->logger->debug('[#' . $line_no . '] Empty content');
                 }
 
@@ -185,34 +186,34 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
                         static::splitTagString($m7[2], $separator)
                     );
                 }
-                $this->items[$i]['tags'] = $tags;
-                $this->logger->debug('[#' . $line_no . '] Tag list: ' . implode(' ', $this->items[$i]['tags']));
+                $items[$i]['tags'] = $tags;
+                $this->logger->debug('[#' . $line_no . '] Tag list: ' . implode(' ', $items[$i]['tags']));
 
                 if (preg_match('/add_date="(.*?)"/i', $line, $m8)) {
-                    $this->items[$i]['time'] = $this->parseDate($m8[1]);
+                    $items[$i]['time'] = $this->parseDate($m8[1]);
                 } else {
-                    $this->items[$i]['time'] = time();
+                    $items[$i]['time'] = time();
                 }
-                $this->logger->debug('[#' . $line_no . '] Date: ' . $this->items[$i]['time']);
+                $this->logger->debug('[#' . $line_no . '] Date: ' . $items[$i]['time']);
 
                 if (preg_match('/(public|published|pub)="(.*?)"/i', $line, $m9)) {
-                    $this->items[$i]['pub'] = $this->parseBoolean($m9[2]) ? 1 : 0;
+                    $items[$i]['pub'] = $this->parseBoolean($m9[2]) ? 1 : 0;
                 } elseif (preg_match('/(private|shared)="(.*?)"/i', $line, $m10)) {
-                    $this->items[$i]['pub'] = $this->parseBoolean($m10[2]) ? 0 : 1;
+                    $items[$i]['pub'] = $this->parseBoolean($m10[2]) ? 0 : 1;
                 } else {
-                    $this->items[$i]['pub'] = $this->defaultPub;
+                    $items[$i]['pub'] = $this->defaultPub;
                 }
                 $this->logger->debug(
-                    '[#' . $line_no . '] Visibility: ' . ($this->items[$i]['pub'] ? 'public' : 'private')
+                    '[#' . $line_no . '] Visibility: ' . ($items[$i]['pub'] ? 'public' : 'private')
                 );
 
                 $i++;
             }
         }
 
-        ksort($this->items);
+        ksort($items);
         $this->logger->info('File parsing ended');
-        return $this->items;
+        return $items;
     }
 
     /**

--- a/NetscapeBookmarkParser.php
+++ b/NetscapeBookmarkParser.php
@@ -212,7 +212,6 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
             }
         }
 
-        ksort($items);
         $this->logger->info('File parsing ended');
         return $items;
     }


### PR DESCRIPTION
Scale down `items` variable scope to method level.
- Makes component stateless and usable as a service.

Refactor `parseString` method.
- Replaced ugly `$i` increment variable with array.

Remove unnecessary `ksort` in `parseString` method.
- Result `$items` array indexes are numeric, `ksort` returns the exact same array everytime.
