### PR TITLE
New feature, parse "ICON" property.

### DIFF
--- a/NetscapeBookmarkParser.php
+++ b/NetscapeBookmarkParser.php
@@ -153,6 +153,14 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
                     $this->logger->debug('[#' . $lineNumber . '] Empty URL');
                 }
 
+                if (preg_match('/icon="(.*?)"/i', $line, $icon)) {
+                    $item['icon'] = $icon[1];
+                    $this->logger->debug('[#' . $lineNumber . '] ICON found: ' . $href[1]);
+                } else {
+                    $item['icon'] = '';
+                    $this->logger->debug('[#' . $lineNumber . '] Empty ICON');
+                }
+
                 if (preg_match('/<a.*?[^br]>(.*?)<\/a>/i', $line, $title)) {
                     $item['title'] = $title[1];
                     $this->logger->debug('[#' . $lineNumber . '] Title found: ' . $title[1]);

--- a/tests/ParseShaarliBookmarksTest.php
+++ b/tests/ParseShaarliBookmarksTest.php
@@ -208,7 +208,8 @@ class ParseShaarliBookmarksTest extends TestCase
                 'note' => 'simple on/off button',
                 'tags' => ['css'],
                 'time' => 1470640652,
-                'pub' => 0
+                'pub' => 0,
+                'icon' => ''
             ],
             $bkm[0]
         );
@@ -221,7 +222,8 @@ class ParseShaarliBookmarksTest extends TestCase
                 'note' => '',
                 'tags' => ['apache'],
                 'time' => 1469950052,
-                'pub' => 1
+                'pub' => 1,
+                'icon' => ''
             ],
             $bkm[1]
         );


### PR DESCRIPTION
`parseString` method now returns and array containing a new `icon` property :

```php
[
  "uri" => "https://discord.com/"
  "icon" => "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8..."
  "title" => "Discord"
  "note" => "foobar"
  "tags" => [
        "bookmarks",
        "bar",
  ]
  "time" => 1592775139
  "pub" => false
]

```

Also, renamed some variables inside `parseString` method:
eg: `$m1` => `$href`,  `$m2` => `$title`...

This is mostly for semantics, and will not impact behavior in any way.