### PR TITLE
[feature] Parsing 'ICON' attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
 composer.lock
 vendor
-logs/
 !.gitkeep
+
+/logs/
+
+###> squizlabs/php_codesniffer ###
+/.phpcs-cache
+/phpcs.xml
+###< squizlabs/php_codesniffer ###

--- a/NetscapeBookmarkParser.php
+++ b/NetscapeBookmarkParser.php
@@ -153,6 +153,14 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
                     $this->logger->debug('[#' . $lineNumber . '] Empty URL');
                 }
 
+                if (preg_match('/icon="(.*?)"/i', $line, $icon)) {
+                    $item['icon'] = $icon[1];
+                    $this->logger->debug('[#' . $lineNumber . '] ICON found: ' . $href[1]);
+                } else {
+                    $item['icon'] = '';
+                    $this->logger->debug('[#' . $lineNumber . '] Empty ICON');
+                }
+
                 if (preg_match('/<a.*?[^br]>(.*?)<\/a>/i', $line, $title)) {
                     $item['title'] = $title[1];
                     $this->logger->debug('[#' . $lineNumber . '] Title found: ' . $title[1]);
@@ -163,7 +171,9 @@ class NetscapeBookmarkParser implements LoggerAwareInterface
 
                 if (preg_match('/(description|note)="(.*?)"/i', $line, $description)) {
                     $item['note'] = $description[2];
-                    $this->logger->debug('[#' . $lineNumber . '] Content found: ' . substr($description[2], 0, 50) . '...');
+                    $this->logger->debug(
+                        '[#' . $lineNumber . '] Content found: ' . substr($description[2], 0, 50) . '...'
+                    );
                 } elseif (preg_match('/<dd>(.*?)$/i', $line, $note)) {
                     $item['note'] = str_replace('<br>', "\n", $note[1]);
                     $this->logger->debug('[#' . $lineNumber . '] Content found: ' . substr($note[1], 0, 50) . '...');

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+
+    <!-- Documentation: https://github.com/squizlabs/PHP_CodeSniffer -->
+
     <arg name="basepath" value="."/>
     <arg name="cache" value=".phpcs-cache"/>
     <arg name="colors"/>
     <arg name="extensions" value="php"/>
 
-    <rule ref="PSR12" />
-    <rule ref="Generic.PHP.RequireStrictTypes.MissingDeclaration" />
-    <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
-
     <file>NetscapeBookmarkParser.php</file>
     <file>tests</file>
+
+    <rule ref="PSR12" />
+
+    <rule ref="Generic.PHP.RequireStrictTypes.MissingDeclaration" />
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+
 </ruleset>

--- a/tests/ParseChromiumBookmarksTest.php
+++ b/tests/ParseChromiumBookmarksTest.php
@@ -19,6 +19,23 @@ class ParseChromiumBookmarksTest extends TestCase
         @unlink(LoggerTestsUtils::getLogFile());
     }
 
+    public function testParseChromiumBookmarkShouldIncludeIcon()
+    {
+        $parser = new NetscapeBookmarkParser(false, null, '1');
+        $bkm = $parser->parseFile('tests/input/chromium_flat.htm');
+
+        // https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-parts-of-a-file
+        // phpcs:disable Generic.Files.LineLength
+        $this->assertEquals('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAACeElEQVQ4jX1TW0hUURRd+8yZuaPOdQxNiSiipAdjICISNhBFVIIRiBoYRP9BSSBFBXPnoyj666O+AoOEmMmpNBUKHSQRiTCDKYqeX6KBzuOa4zzu2X3M+NbW1zn77LX3WntzgI1gsFh1Z6Z1sTzkuggzgUgBAB4nSt1SqThRFADn33jzAvmEPU/jDXA6L1E6tUMxVFn3wg9rIen/TTSxtgitIAsQqf2BeBsT34bNfnlfeeFQZDIqSMhWCe7IZLjt51f3eM5mXiUAoIVtee/yYCgeORCarVrrbG9g5mxVKBbeYE5MAFD9PFpS22c+rHkZ688lhJftBXIN6nvjX04MzXVUPpkpXrQsAOL6vsQFTWLEoWkuAXULzAQML0tsJQsA0hbfTMBRXVpMo95XsRYQMR0eiDaRwh3Fsmm0UY9sspVVkz/UG6uRQnURc7vUiK6RxMXBk3oEYZYY9qvKunP27++6MjAMBSL2BNjx6TOyeb4YO03jx15Hr5OiG9QwGP0l55Oe3sZtSfj9BMNQx9/Mep02WafY6ibBuhDijFOlHwWPlk8BTDD85K1td+savxd2sJovcBW0BIMCPh8DTFn5cYyt9IAg4UGWt3Mi2xkcfvBnkWz4fCgpyBZKwRlqHoq+gA0Tz45sMdb5/w+aw7P3FKOC2t7GdrNl9ZBAyGXZ7yfT88lpAG6HoFSCCADcu8rU9NQ0KgDAVVRkqcwVZpxKWdxIAHB+ZHKnUtpdaYOHhC3DSoFZ5UZPAEGAAGYiAitpKf4gNefVzjrXFK1cU0P/t+KS8gqHjjmYJqDrLphmTrKuAyaAvwupVI93q7m04qXDJt91QzCLRfI/LI8pZq5PEwYAAAAASUVORK5CYII=', $bkm[0]['icon']);
+        // phpcs:enable
+
+        $parser = new NetscapeBookmarkParser(true, null, '1');
+        $bkm = $parser->parseFile('tests/input/chromium_nested.htm');
+        // phpcs:disable Generic.Files.LineLength
+        $this->assertEquals('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAB2UlEQVQ4jYWTz2uScRzHXz5uQfp46i6uQ4QhQf4DgzpFPVtKlxmNrkG2npOSY1rgcX/ARoeCdliroHaJLYg8RoeQIDoEQqvUkqRNI/V5dzAft/mjL3zh++HL683788vzfI71Cye4jIeB87sNjsA3OfiHYPMjjzzKomFwowWL70+DMUHu5FvMI8NFjHFwemWbzOoWSx+i7P4ZIuABYxR8Y/kppmni8/m4ufxkpIhxGL724hjplW1CoSm+ff3Czs5ngsEgmdUtUu8iAyLGfth6COtvfpDP5/lerTI7e4kZa4ZKpUy73eLO/VeDTpRDexl0dgp1y4JM09SthQU3zmaX1Gg0JEmlUkl2PKpft5FyiObiQThgmioUCnIcR+lUSrZty3Ec1et1VStlNZtN1Wo12fGo9jLI6FXTdSThdDq9LrmnWCxy0bKo138iCfSv+24Kx/su/H6/riQSbpxMJhUIBAToVDgsO3ZGu70UlOs+Dov0biQSUaVcVjqVEqDpEC6sHPIo13faaIG1Bi8/uXPCxuMNYrE4tVqN6+fD3DtXxr9vKif299Q3Cc/m+iIC5q/O4/V6ef3g7gAMcMDBKCfTIdhMMAB3BcYsk7UGHWc0jMDzv3WW4OiYdf4LzLYa1HClursAAAAASUVORK5CYII=', $bkm[1]['icon']);
+        // phpcs:enable
+    }
+
     /**
      * Parse flat Chromium bookmarks (no directories)
      */

--- a/tests/ParseShaarliBookmarksTest.php
+++ b/tests/ParseShaarliBookmarksTest.php
@@ -208,7 +208,8 @@ class ParseShaarliBookmarksTest extends TestCase
                 'note' => 'simple on/off button',
                 'tags' => ['css'],
                 'time' => 1470640652,
-                'pub' => 0
+                'pub' => 0,
+                'icon' => ''
             ],
             $bkm[0]
         );
@@ -221,7 +222,8 @@ class ParseShaarliBookmarksTest extends TestCase
                 'note' => '',
                 'tags' => ['apache'],
                 'time' => 1469950052,
-                'pub' => 1
+                'pub' => 1,
+                'icon' => ''
             ],
             $bkm[1]
         );


### PR DESCRIPTION
### 1. New feature

`parseString` method now returns and array containing a new `icon` property :

```php
[
  "uri" => "https://discord.com/"
  "icon" => "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8..."
  "title" => "Discord"
  "note" => "foobar"
  "tags" => [
        "bookmarks",
        "bar",
  ]
  "time" => 1592775139
  "pub" => false
]

```

### 2. Unit tests

Updated associated unit test.

### 3. Semantics

Renamed some variables inside `parseString` method:
eg: `$m1` => `$href`,  `$m2` => `$title`...

This is mostly for semantics, and will not impact behavior in any way.

### 4. gitignore

Added `.phpcs-cache` in `.gitignore`
