### PR TITLE
Add editorconfig file back

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig: http://EditorConfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{htm,html,xml,yml}]
+indent_size = 2
+
+[*.php]
+max_line_length = 120
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
This is useful to keep the same coding rules across any IDE and OS, especially regarding line and file endings.
See https://editorconfig.org/

This also the occasion to test the Github Action workflow,