### PR TITLE
Update NetscapeBookmarkEncoder.php

### DIFF
--- a/src/Encoder/NetscapeBookmarkEncoder.php
+++ b/src/Encoder/NetscapeBookmarkEncoder.php
@@ -72,7 +72,7 @@ class NetscapeBookmarkEncoder
             foreach ($tag['bookmarks'] as $bookmark) {
                 $result .= sprintf('<DT><A HREF="%s"', $bookmark['url']);
                 if ($bookmark['dateCreated'] ?? null) {
-                    $result .= sprintf('> ADD_DATE="%s"', $bookmark['dateCreated']);
+                    $result .= sprintf(' ADD_DATE="%s"', $bookmark['dateCreated']);
                 }
                 if ($bookmark['public'] ?? null) {
                     $result .= sprintf(' PRIVATE="%s"', $bookmark['public'] ? '0' : '1');


### PR DESCRIPTION
Remove  '>' that prematurely closed the <A> tag if adding dateCreated during encoding.